### PR TITLE
Fix camera clipping with swept Box3D camera volume

### DIFF
--- a/sim/control_settings.mjs
+++ b/sim/control_settings.mjs
@@ -8,6 +8,7 @@ const OBSOLETE_KEYS=[
   "arondight45PhoneControlSettingsV3",
   "arondight45PhoneControlSettingsV4",
 ];
+const GAMEPAD_MENU_BUTTON=Object.freeze({A:0,B:1,START:9,DPAD_UP:12,DPAD_DOWN:13,DPAD_LEFT:14,DPAD_RIGHT:15});
 
 function clearObsoleteSettings(){
   try{for(const key of OBSOLETE_KEYS)localStorage.removeItem(key);}catch{}
@@ -27,6 +28,64 @@ export function savePhoneControlSettings(settings){
   return normalized;
 }
 
+function gamepadButtonPressed(gamepad,index){
+  const value=gamepad?.buttons?.[index];return typeof value==="number"?value>.5:Boolean(value?.pressed||Number(value?.value)>.5);
+}
+function settingsGamepad(){
+  try{return Array.from(navigator.getGamepads?.()||[]).find(pad=>pad?.connected&&(pad.mapping==="standard"||/xbox|xinput|045e/i.test(String(pad.id||""))))||null;}catch{return null;}
+}
+function visibleDialogControls(dialog){
+  return Array.from(dialog.querySelectorAll('button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])')).filter(element=>{
+    if(!(element instanceof HTMLElement))return false;const style=getComputedStyle(element);return style.display!=="none"&&style.visibility!=="hidden"&&element.getClientRects().length>0;
+  });
+}
+function focusDialogControl(dialog,delta=0){
+  const controls=visibleDialogControls(dialog);if(!controls.length)return false;let index=controls.indexOf(document.activeElement);if(index<0)index=delta<0?0:-1;index=(index+delta+controls.length)%controls.length;const target=controls[index];target.focus({preventScroll:true});target.scrollIntoView({block:"nearest",inline:"nearest"});return true;
+}
+function activateDialogControl(dialog){
+  const element=document.activeElement;if(!(element instanceof HTMLElement)||!dialog.contains(element)){focusDialogControl(dialog,1);return true;}
+  if(element instanceof HTMLInputElement&&(element.type==="checkbox"||element.type==="radio")){element.click();return true;}
+  if(element instanceof HTMLButtonElement){element.click();return true;}
+  if(element instanceof HTMLSelectElement){try{element.showPicker?.();}catch{}return true;}
+  return false;
+}
+function adjustDialogControl(dialog,direction){
+  const element=document.activeElement;if(!(element instanceof HTMLElement)||!dialog.contains(element))return focusDialogControl(dialog,direction);
+  if(element instanceof HTMLInputElement&&element.type==="range"){
+    const min=Number.isFinite(Number(element.min))?Number(element.min):-Infinity,max=Number.isFinite(Number(element.max))?Number(element.max):Infinity,step=Number(element.step)||1,next=Math.max(min,Math.min(max,Number(element.value)+step*Math.sign(direction)));if(next===Number(element.value))return true;element.value=String(next);element.dispatchEvent(new Event("input",{bubbles:true}));return true;
+  }
+  if(element instanceof HTMLInputElement&&(element.type==="checkbox"||element.type==="radio")){
+    const next=direction>0;if(element.checked!==next){element.checked=next;element.dispatchEvent(new Event("change",{bubbles:true}));}return true;
+  }
+  if(element instanceof HTMLSelectElement){const next=Math.max(0,Math.min(element.options.length-1,element.selectedIndex+Math.sign(direction)));if(next!==element.selectedIndex){element.selectedIndex=next;element.dispatchEvent(new Event("change",{bubbles:true}));}return true;}
+  return focusDialogControl(dialog,direction);
+}
+function installGamepadDialogNavigation({dialog,openDialog,closeDialog}){
+  let previous=Array(16).fill(false),axisX=0,axisY=0,nextAxisX=0,nextAxisY=0,raf=0;
+  const pulseAxis=(now,axis,previousAxis,nextAt,negative,positive,action)=>{
+    const direction=axis<-.62?-1:axis>.62?1:0;if(!direction)return{held:0,next:0};const changed=direction!==previousAxis;if(changed||now>=nextAt){action(direction<0?negative:positive);return{held:direction,next:now+(changed?300:145)};}return{held:previousAxis,next:nextAt};
+  };
+  const frame=now=>{
+    const pad=settingsGamepad();if(!pad){previous.fill(false);axisX=axisY=0;nextAxisX=nextAxisY=0;raf=requestAnimationFrame(frame);return;}
+    const current=previous.map((_,index)=>gamepadButtonPressed(pad,index)),edge=index=>current[index]&&!previous[index];
+    if(edge(GAMEPAD_MENU_BUTTON.START)){if(dialog.open)closeDialog();else openDialog({gamepad:true});}
+    if(dialog.open){
+      if(edge(GAMEPAD_MENU_BUTTON.B))closeDialog();else{
+        if(edge(GAMEPAD_MENU_BUTTON.A))activateDialogControl(dialog);
+        if(edge(GAMEPAD_MENU_BUTTON.DPAD_UP))focusDialogControl(dialog,-1);
+        if(edge(GAMEPAD_MENU_BUTTON.DPAD_DOWN))focusDialogControl(dialog,1);
+        if(edge(GAMEPAD_MENU_BUTTON.DPAD_LEFT))adjustDialogControl(dialog,-1);
+        if(edge(GAMEPAD_MENU_BUTTON.DPAD_RIGHT))adjustDialogControl(dialog,1);
+        const x=Number(pad.axes?.[0])||0,y=Number(pad.axes?.[1])||0;
+        const yState=pulseAxis(now,y,axisY,nextAxisY,-1,1,direction=>focusDialogControl(dialog,direction));axisY=yState.held;nextAxisY=yState.next;
+        const xState=pulseAxis(now,x,axisX,nextAxisX,-1,1,direction=>adjustDialogControl(dialog,direction));axisX=xState.held;nextAxisX=xState.next;
+      }
+    }else{axisX=axisY=0;nextAxisX=nextAxisY=0;}
+    previous=current;raf=requestAnimationFrame(frame);
+  };
+  raf=requestAnimationFrame(frame);return()=>cancelAnimationFrame(raf);
+}
+
 let styleInstalled=false;
 function installStyle(){
   if(styleInstalled)return;styleInstalled=true;
@@ -36,6 +95,7 @@ function installStyle(){
   .phone-settings-button{white-space:nowrap}
   .phone-settings-dialog{width:min(92vw,390px)!important;max-height:90dvh!important;overflow:auto!important;border:1px solid #ffffff44!important;border-radius:14px!important;background:#0b1420f4!important;color:#fff!important;padding:16px!important;box-shadow:0 20px 70px #000a!important}
   .phone-settings-dialog::backdrop{background:#0009;backdrop-filter:blur(5px)}
+  .phone-settings-dialog :is(button,input,select,textarea):focus{outline:3px solid #6be4b0!important;outline-offset:3px!important;box-shadow:0 0 0 2px #071522,0 0 18px #6be4b077!important}
   .phone-settings-dialog h3{margin:0 0 5px;font:800 17px system-ui,-apple-system,sans-serif}
   .camera-settings-section,.world-settings-section{margin-top:18px;padding-top:4px;border-top:2px solid #ffffff2b}
   .camera-settings-section h4,.world-settings-section h4{margin:12px 0 4px;font:850 14px system-ui,-apple-system,sans-serif;letter-spacing:.08em;color:#6be4b0}
@@ -55,6 +115,7 @@ function installStyle(){
   .world-settings-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:10px 0}
   .world-settings-actions [data-world-use]{background:#175f49;border-color:#2e9b77}
   .world-settings-status{padding:9px 10px;margin:8px 0 10px;border:1px solid #ffffff2e;border-radius:9px;background:#07101a;color:#9db0c9;font:750 11px/1.35 system-ui,-apple-system,sans-serif}
+  body.gamepad-settings-open #soloLeft,body.gamepad-settings-open #soloRight,body.gamepad-settings-open #soloClearance,body.gamepad-settings-open #soloArm,body.gamepad-settings-open #soloKill{display:none!important}
   body.solo-flight #soloTopbar .world-mode-button{display:inline-flex!important;flex:0 0 auto;min-width:54px;min-height:28px;align-items:center;justify-content:center;white-space:nowrap}
   body.solo-flight #soloTopbar .world-mode-button[data-active="1"]{background:#175f49!important;border-color:#62d6aa!important;color:#fff!important}
   body.solo-flight #soloTopbar .world-mode-button[data-loading="1"]{background:#7b5a18!important;border-color:#ffd06d!important}
@@ -76,7 +137,7 @@ function mountSoloWorldSettings({parent,dialog,settingsButton}){
     <label class="phone-settings-toggle"><span>KEEP 360° LOOK ORIENTATION</span><input data-world-keep-look type="checkbox"></label>
     <label class="phone-settings-toggle"><span>LOCK MINIMAP AXIS TO VERTICAL</span><input data-world-minimap-axis-lock type="checkbox"></label>
     <p class="phone-settings-note">REAL AERIAL / SATELLITE MAP is ON by default in both the flight view and minimap. WORLD GRID is a render-only local metre reference. 360° LOOK is camera-only: OFF snaps smoothly back on release; ON keeps the released orientation. LOCK MINIMAP AXIS is ON by default and keeps the orthographic top-down map north-up during persistent look/orientation changes outside fullscreen. Fullscreen always uses its native landscape/north-up policy.</p>
-    <p class="phone-settings-note">Nearby loaded OSM building footprints, holes and available min/max heights are installed as bounded static Box3D collision prisms, so the airframe and downward NAV range ray see walls and roofs. Imagery, roads and flat ground remain geospatial context; OSM geometry is approximate, not surveyed 1:1 world truth. Motor, sensor and FC authority stay on the same hardware-fit path.</p>`;
+    <p class="phone-settings-note">Nearby loaded OSM building footprints, holes and available min/max heights are installed as bounded static Box3D collision prisms, so the airframe collides with walls and roofs. Imagery, roads and flat ground remain geospatial context; OSM geometry is approximate, not surveyed 1:1 world truth. Motor, sensor and FC authority stay on the same hardware-fit path.</p>`;
   const actions=dialog.querySelector(".phone-settings-actions");dialog.insertBefore(section,actions);
   const status=section.querySelector("[data-world-status]"),use=section.querySelector("[data-world-use]"),training=section.querySelector("[data-world-training]"),imagery=section.querySelector("[data-world-imagery]"),grid=section.querySelector("[data-world-grid]"),keepLook=section.querySelector("[data-world-keep-look]"),axisLock=section.querySelector("[data-world-minimap-axis-lock]");
   const worldButton=document.createElement("button");worldButton.id="soloWorld";worldButton.type="button";worldButton.className="world-mode-button";worldButton.setAttribute("aria-label","Toggle real-world GPS map");parent.insertBefore(worldButton,settingsButton||null);
@@ -127,7 +188,7 @@ export function mountPhoneControlSettings({parent,buttonText="SETTINGS",onChange
     <label class="phone-settings-toggle"><span>INVERT RIGHT STICK VERTICAL (UP/DOWN)</span><input data-invert-right-vertical type="checkbox"></label>
     <label class="phone-settings-toggle"><span>LOCK LEFT STICK HORIZONTAL AXIS</span><input data-lock-left-horizontal type="checkbox"></label>
     <label class="phone-settings-toggle"><span>LOCK RIGHT STICK VERTICAL AXIS</span><input data-lock-horizontal type="checkbox"></label>
-    ${xboxControllerToggle?'<label class="phone-settings-toggle"><span>XBOX CONTROLLER</span><input data-xbox-controller type="checkbox"></label><p class="phone-settings-note">OFF is the default and keeps touch controls active. ON reserves Xbox/standard-gamepad control and removes every touch flight control from the image, including while the selected controller reconnects.</p>':''}
+    ${xboxControllerToggle?'<label class="phone-settings-toggle"><span>XBOX CONTROLLER</span><input data-xbox-controller type="checkbox"></label><p class="phone-settings-note">OFF is the default and keeps touch controls active. ON reserves Xbox/standard-gamepad control and removes every touch flight control from the image, including while the selected controller reconnects. Controller menu: START open/close · D-PAD/LEFT STICK navigate · A select · B back/close.</p>':''}
     ${debugGrid?'<label class="phone-settings-toggle"><span>DEBUG GRIDLINES</span><input data-debug-grid type="checkbox"></label><p class="phone-settings-note">DEBUG GRIDLINES affect only the local training renderer. They never alter WORLD GRID, sensors, collision, FC state or physics.</p>':''}
     ${box3dColliderDebug?'<label class="phone-settings-toggle"><span>DEBUG COLLISION DRAW</span><input data-box3d-collider-debug type="checkbox"></label><p class="phone-settings-note">DEBUG COLLISION DRAW is render-only. OFF immediately hides Box3D ground, airframe and building collider wireframes and persists OFF locally.</p>':''}
     <p class="phone-settings-note">Left X invert reverses MANUAL yaw / GAME strafe. Right X/Y invert independently reverse TURN and body pitch. MAX HORIZONTAL SPEED scales the real GAME velocity request sent through SBUS to the shared StateController; acceleration, tilt, mixer and motor authority remain flight-controller bounded. Settings are stored locally on this device.</p>
@@ -140,6 +201,8 @@ export function mountPhoneControlSettings({parent,buttonText="SETTINGS",onChange
     left.value=String(settings.leftFineness);right.value=String(settings.rightFineness);speed.value=String(settings.maxHorizontalSpeedKmh);hover.value=String(settings.defaultHoverAgl);
     leftOut.value=`${left.value}/10`;rightOut.value=`${right.value}/10`;speedOut.value=`${Math.round(Number(speed.value))} km/h`;hoverOut.value=`${Number(hover.value).toFixed(1)} m`;invertLeft.checked=settings.invertLeftHorizontal;invertRight.checked=settings.invertRightHorizontal;invertRightVertical.checked=settings.invertRightVertical;lockLeft.checked=settings.lockLeftHorizontal;lock.checked=settings.lockRightHorizontal;if(xboxControllerInput)xboxControllerInput.checked=settings.xboxControllerEnabled!==false;if(debugGridInput)debugGridInput.checked=Boolean(debugGrid?.get?.());if(box3dColliderDebugInput)box3dColliderDebugInput.checked=Boolean(box3dColliderDebug?.get?.());
   };
+  const syncGamepadMenuClass=()=>document.body.classList.toggle("gamepad-settings-open",Boolean(dialog.open&&settings.xboxControllerEnabled));
+  const emitChange=()=>{syncGamepadMenuClass();onChange({...settings,xboxControllerEnabled:dialog.open&&settings.xboxControllerEnabled?false:settings.xboxControllerEnabled});};
   const apply=()=>{
     settings=savePhoneControlSettings({
       leftFineness:Number(left.value),
@@ -153,13 +216,17 @@ export function mountPhoneControlSettings({parent,buttonText="SETTINGS",onChange
       lockRightHorizontal:lock.checked,
       xboxControllerEnabled:xboxControllerInput?xboxControllerInput.checked:settings.xboxControllerEnabled,
     });
-    render();onChange({...settings});
+    render();emitChange();
   };
   left.addEventListener("input",apply);right.addEventListener("input",apply);speed.addEventListener("input",apply);hover.addEventListener("input",apply);invertLeft.addEventListener("change",apply);invertRight.addEventListener("change",apply);invertRightVertical.addEventListener("change",apply);lockLeft.addEventListener("change",apply);lock.addEventListener("change",apply);if(xboxControllerInput)xboxControllerInput.addEventListener("change",apply);if(debugGridInput)debugGridInput.addEventListener("change",()=>{debugGrid?.set?.(debugGridInput.checked);render();});if(box3dColliderDebugInput)box3dColliderDebugInput.addEventListener("change",()=>{box3dColliderDebug?.set?.(box3dColliderDebugInput.checked);render();});
-  dialog.querySelector("[data-reset]").onclick=()=>{settings=savePhoneControlSettings(DEFAULT_PHONE_SETTINGS);debugGrid?.set?.(Boolean(debugGrid?.defaultValue));box3dColliderDebug?.set?.(Boolean(box3dColliderDebug?.defaultValue));render();onChange({...settings});};
-  dialog.querySelector("[data-close]").onclick=()=>dialog.close();
-  button.onclick=()=>{settings=loadPhoneControlSettings();render();dialog.showModal();};
+  dialog.querySelector("[data-reset]").onclick=()=>{settings=savePhoneControlSettings(DEFAULT_PHONE_SETTINGS);debugGrid?.set?.(Boolean(debugGrid?.defaultValue));box3dColliderDebug?.set?.(Boolean(box3dColliderDebug?.defaultValue));render();emitChange();};
+  const openDialog=()=>{if(dialog.open)return;settings=loadPhoneControlSettings();render();dialog.showModal();syncGamepadMenuClass();emitChange();requestAnimationFrame(()=>{if(!dialog.contains(document.activeElement))focusDialogControl(dialog,1);});};
+  const closeDialog=()=>{if(dialog.open)dialog.close();};
+  dialog.querySelector("[data-close]").onclick=closeDialog;
+  dialog.addEventListener("close",()=>{document.body.classList.remove("gamepad-settings-open");onChange({...settings});button.focus({preventScroll:true});});
+  button.onclick=openDialog;
   const world=mountSoloWorldSettings({parent,dialog,settingsButton:button});
+  if(xboxControllerToggle)installGamepadDialogNavigation({dialog,openDialog,closeDialog});
   render();
   return{button,dialog,world,get settings(){return{...settings};},reload(){settings=loadPhoneControlSettings();render();return{...settings};}};
 }

--- a/sim/control_settings.mjs
+++ b/sim/control_settings.mjs
@@ -9,6 +9,7 @@ const OBSOLETE_KEYS=[
   "arondight45PhoneControlSettingsV4",
 ];
 const GAMEPAD_MENU_BUTTON=Object.freeze({A:0,B:1,START:9,DPAD_UP:12,DPAD_DOWN:13,DPAD_LEFT:14,DPAD_RIGHT:15});
+const GAMEPAD_FLIGHT_BUTTONS=Object.freeze([0,1,2,3,4,5,6,7,9]);
 
 function clearObsoleteSettings(){
   try{for(const key of OBSOLETE_KEYS)localStorage.removeItem(key);}catch{}
@@ -33,6 +34,9 @@ function gamepadButtonPressed(gamepad,index){
 }
 function settingsGamepad(){
   try{return Array.from(navigator.getGamepads?.()||[]).find(pad=>pad?.connected&&(pad.mapping==="standard"||/xbox|xinput|045e/i.test(String(pad.id||""))))||null;}catch{return null;}
+}
+function flightGamepadNeutral(gamepad){
+  if(!gamepad)return true;const axes=[0,1,2,3].every(index=>Math.abs(Number(gamepad.axes?.[index])||0)<.24),buttons=GAMEPAD_FLIGHT_BUTTONS.every(index=>!gamepadButtonPressed(gamepad,index));return axes&&buttons;
 }
 function visibleDialogControls(dialog){
   return Array.from(dialog.querySelectorAll('button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])')).filter(element=>{
@@ -156,7 +160,7 @@ function mountSoloWorldSettings({parent,dialog,settingsButton}){
 export function mountPhoneControlSettings({parent,buttonText="SETTINGS",onChange=()=>{},debugGrid=null,box3dColliderDebug=null,xboxControllerToggle=false}={}){
   if(!parent)throw Error("settings parent required");
   installStyle();
-  let settings=loadPhoneControlSettings();
+  let settings=loadPhoneControlSettings(),resumeToken=0;
   const button=document.createElement("button");
   button.type="button";button.className="phone-settings-button";button.textContent=buttonText;button.setAttribute("aria-label","Phone control settings");
   const dialog=document.createElement("dialog");dialog.className="phone-settings-dialog";
@@ -220,10 +224,14 @@ export function mountPhoneControlSettings({parent,buttonText="SETTINGS",onChange
   };
   left.addEventListener("input",apply);right.addEventListener("input",apply);speed.addEventListener("input",apply);hover.addEventListener("input",apply);invertLeft.addEventListener("change",apply);invertRight.addEventListener("change",apply);invertRightVertical.addEventListener("change",apply);lockLeft.addEventListener("change",apply);lock.addEventListener("change",apply);if(xboxControllerInput)xboxControllerInput.addEventListener("change",apply);if(debugGridInput)debugGridInput.addEventListener("change",()=>{debugGrid?.set?.(debugGridInput.checked);render();});if(box3dColliderDebugInput)box3dColliderDebugInput.addEventListener("change",()=>{box3dColliderDebug?.set?.(box3dColliderDebugInput.checked);render();});
   dialog.querySelector("[data-reset]").onclick=()=>{settings=savePhoneControlSettings(DEFAULT_PHONE_SETTINGS);debugGrid?.set?.(Boolean(debugGrid?.defaultValue));box3dColliderDebug?.set?.(Boolean(box3dColliderDebug?.defaultValue));render();emitChange();};
-  const openDialog=()=>{if(dialog.open)return;settings=loadPhoneControlSettings();render();dialog.showModal();syncGamepadMenuClass();emitChange();requestAnimationFrame(()=>{if(!dialog.contains(document.activeElement))focusDialogControl(dialog,1);});};
+  const openDialog=()=>{if(dialog.open)return;resumeToken++;settings=loadPhoneControlSettings();render();dialog.showModal();syncGamepadMenuClass();emitChange();requestAnimationFrame(()=>{if(!dialog.contains(document.activeElement))focusDialogControl(dialog,1);});};
   const closeDialog=()=>{if(dialog.open)dialog.close();};
+  const restoreFlightAfterMenu=()=>{
+    const token=++resumeToken;if(!settings.xboxControllerEnabled){document.body.classList.remove("gamepad-settings-open");onChange({...settings});button.focus({preventScroll:true});return;}
+    document.body.classList.add("gamepad-settings-open");const wait=()=>{if(token!==resumeToken||dialog.open)return;if(!flightGamepadNeutral(settingsGamepad())){requestAnimationFrame(wait);return;}document.body.classList.remove("gamepad-settings-open");onChange({...settings});button.focus({preventScroll:true});};requestAnimationFrame(wait);
+  };
   dialog.querySelector("[data-close]").onclick=closeDialog;
-  dialog.addEventListener("close",()=>{document.body.classList.remove("gamepad-settings-open");onChange({...settings});button.focus({preventScroll:true});});
+  dialog.addEventListener("close",restoreFlightAfterMenu);
   button.onclick=openDialog;
   const world=mountSoloWorldSettings({parent,dialog,settingsButton:button});
   if(xboxControllerToggle)installGamepadDialogNavigation({dialog,openDialog,closeDialog});

--- a/sim/world_building_collision_physics.mjs
+++ b/sim/world_building_collision_physics.mjs
@@ -2,6 +2,7 @@ const finitePoint=point=>Array.isArray(point)&&point.length===2&&point.every(Num
 const DEFAULT_LAUNCH_EXCLUSION_POINT=Object.freeze([0,0]);
 const LAUNCH_AIRFRAME_CENTER_Z_M=.024;
 const LAUNCH_AIRFRAME_HALF_Z_M=.022;
+const DEFAULT_CAMERA_RADIUS_M=.12;
 
 function pointInPolygon(point,ring){
   if(!finitePoint(point)||!Array.isArray(ring)||ring.length<3)return false;const[x,y]=point;let inside=false;
@@ -51,23 +52,12 @@ export function findClearBuildingLaunchPoint(value,{point=DEFAULT_LAUNCH_EXCLUSI
 
 export function createWorldBuildingCollisionBodies(b3,world,value,{categoryBits=1n,maskBits=6n,rangefinderCategoryBits=4n,launchExclusionPoint=DEFAULT_LAUNCH_EXCLUSION_POINT}={}){
   const snapshot=normalizeBuildingCollisionSnapshot(value);if(!world||!snapshot.prisms.length)return{body:null,shapeCount:0,skippedLaunchPrisms:0,skippedLaunchBuildings:0,activePrisms:Object.freeze([]),...snapshot};
-  // Concave/holed OSM buildings are decomposed into several convex prisms. If the
-  // launch point lands in any one of those prisms, the whole source building must
-  // be excluded. Skipping only the containing triangle creates an invisible solid
-  // seam at its neighbour: lateral strafe then chatters against that seam and can
-  // appear to stop responding even though the stick/FC command is still valid.
   const launchExcludedBuildingKeys=new Set();
   for(const prism of snapshot.prisms){
     if(!overlapsLaunchVolume(prism,launchExclusionPoint))continue;
     const key=String(prism.buildingKey||"");if(key)launchExcludedBuildingKeys.add(key);
   }
   const bodyDef=b3.b3DefaultBodyDef();bodyDef.type=b3.b3BodyType.b3_staticBody;bodyDef.position=[0,0,0];const body=b3.b3CreateBody(world,bodyDef),shapeDef=b3.b3DefaultShapeDef();shapeDef.baseMaterial.friction=.68;shapeDef.baseMaterial.restitution=.025;
-  // Buildings are physical airframe obstacles, not the GAME altitude datum. The
-  // downward NAV ray must keep measuring the stable launch/terrain plane; letting
-  // it hit OSM roofs makes AGL jump by an entire building height at each roof edge
-  // and feeds that discontinuity straight into the vertical controller while the
-  // pilot is translating. Preserve airframe collision but exclude the rangefinder
-  // query category from every building shape.
   const collisionMask=BigInt(maskBits)&~BigInt(rangefinderCategoryBits);
   shapeDef.filter={categoryBits:BigInt(categoryBits),maskBits:collisionMask,groupIndex:0};let shapeCount=0,skippedLaunchPrisms=0;const activePrisms=[];
   for(const prism of snapshot.prisms){
@@ -81,12 +71,22 @@ export function createWorldBuildingCollisionBodies(b3,world,value,{categoryBits=
   if(!shapeCount){b3.b3DestroyBody(body);return{body:null,shapeCount:0,skippedLaunchPrisms,skippedLaunchBuildings,activePrisms:Object.freeze([]),...snapshot};}return{body,shapeCount,skippedLaunchPrisms,skippedLaunchBuildings,activePrisms:Object.freeze(activePrisms.slice()),...snapshot};
 }
 
-export function resolveBox3dCameraPath(b3,world,anchor,desired,{queryCategoryBits=8n,terrainCategoryBits=1n,clearanceM=.08}={}){
+export function resolveBox3dCameraPath(b3,world,anchor,desired,{queryCategoryBits=8n,terrainCategoryBits=1n,clearanceM=.025,cameraRadiusM=DEFAULT_CAMERA_RADIUS_M}={}){
   const from=Array.isArray(anchor)?anchor.map(Number):[],to=Array.isArray(desired)?desired.map(Number):[];if(from.length!==3||to.length!==3||![...from,...to].every(Number.isFinite))return{position:to.length===3?to:[0,0,0],collided:false,fraction:1,hitDistanceM:0};
   const delta=[to[0]-from[0],to[1]-from[1],to[2]-from[2]],distance=Math.hypot(...delta);if(!world||distance<1e-6)return{position:[...to],collided:false,fraction:1,hitDistanceM:distance};
-  const filter=b3.b3DefaultQueryFilter();filter.categoryBits=BigInt(queryCategoryBits);filter.maskBits=BigInt(terrainCategoryBits);const hit=b3.b3World_CastRayClosest(world,from,delta,filter),fraction=Number(hit?.fraction);
-  if(!hit?.hit||!Number.isFinite(fraction)||fraction<0||fraction>1)return{position:[...to],collided:false,fraction:1,hitDistanceM:distance};
-  const hitDistance=Math.max(0,Math.min(distance,fraction*distance)),safeDistance=Math.max(0,hitDistance-Math.max(.01,Number(clearanceM)||.08)),scale=safeDistance/distance;return{position:[from[0]+delta[0]*scale,from[1]+delta[1]*scale,from[2]+delta[2]*scale],collided:true,fraction,hitDistanceM:hitDistance};
+  const filter=b3.b3DefaultQueryFilter();filter.categoryBits=BigInt(queryCategoryBits);filter.maskBits=BigInt(terrainCategoryBits);
+  const radius=Math.max(.03,Math.min(.30,Number(cameraRadiusM)||DEFAULT_CAMERA_RADIUS_M));let fraction=1,collided=false;
+  if(typeof b3.b3World_CastMover==="function"){
+    const mover={center1:[0,0,0],center2:[0,0,0],radius};
+    const result=Number(b3.b3World_CastMover(world,from,mover,delta,filter,()=>true));
+    if(Number.isFinite(result)&&result>=0&&result<1){fraction=Math.max(0,Math.min(1,result));collided=true;}
+  }else{
+    const hit=b3.b3World_CastRayClosest(world,from,delta,filter),rayFraction=Number(hit?.fraction);
+    if(hit?.hit&&Number.isFinite(rayFraction)&&rayFraction>=0&&rayFraction<=1){fraction=rayFraction;collided=true;}
+  }
+  if(!collided)return{position:[...to],collided:false,fraction:1,hitDistanceM:distance,cameraRadiusM:radius};
+  const hitDistance=Math.max(0,Math.min(distance,fraction*distance)),safeDistance=Math.max(0,hitDistance-Math.max(.005,Number(clearanceM)||.025)),scale=safeDistance/distance;
+  return{position:[from[0]+delta[0]*scale,from[1]+delta[1]*scale,from[2]+delta[2]*scale],collided:true,fraction,hitDistanceM:hitDistance,cameraRadiusM:radius};
 }
 
 export function destroyWorldBuildingCollisionBodies(b3,state){if(state?.body&&b3.b3Body_IsValid(state.body))b3.b3DestroyBody(state.body);}

--- a/tests/world_building_collision_box3d_test.mjs
+++ b/tests/world_building_collision_box3d_test.mjs
@@ -11,14 +11,9 @@ const b3=await factory();
 const worldDef=b3.b3DefaultWorldDef();worldDef.gravity=[0,0,0];worldDef.enableSleep=false;worldDef.enableContinuous=true;
 const world=b3.b3CreateWorld(worldDef);
 
-// Stable GAME AGL datum: the flat launch/terrain plane remains visible to the
-// rangefinder even when an OSM building is physically present above it.
 const groundDef=b3.b3DefaultBodyDef();groundDef.position=[0,0,-.05];const ground=b3.b3CreateBody(world,groundDef),groundShape=b3.b3DefaultShapeDef();groundShape.filter={categoryBits:1n,maskBits:14n,groupIndex:0};b3.b3CreateBoxShape(ground,groundShape,10,10,.05);
 
 const snapshot={hash:"fixture",footprintCount:2,prisms:[
-  // A concave/triangulated source building can produce several convex prisms.
-  // Only the first prism contains the launch point; the second prism is the seam
-  // that used to catch left/right strafe immediately after takeoff.
   {buildingKey:"launch-house",base:0,top:3,points:[[-.5,-.5],[.5,-.5],[.5,.5],[-.5,.5]]},
   {buildingKey:"launch-house",base:0,top:3,points:[[.5,-.5],[1.5,-.5],[1.5,.5],[.5,.5]]},
   {buildingKey:"house",base:0,top:2,points:[[2,-1],[3,-1],[3,1],[2,1]]},
@@ -31,18 +26,22 @@ assert.ok(safeLaunch[1]<-.65,`nearest deterministic clear launch should leave th
 const buildings=createWorldBuildingCollisionBodies(b3,world,snapshot,{categoryBits:1n,maskBits:14n,rangefinderCategoryBits:4n,launchExclusionPoint:safeLaunch});
 assert.equal(buildings.shapeCount,3);assert.equal(buildings.prismCount,3);assert.equal(buildings.skippedLaunchPrisms,0);assert.equal(buildings.skippedLaunchBuildings,0);assert.equal(buildings.activePrisms.length,3);assert.ok(buildings.body&&b3.b3Body_IsValid(buildings.body));
 
-// Regression: OSM roofs/walls remain airframe colliders but must not become the
-// altitude controller's AGL datum. A downward NAV query through the 2 m roof must
-// continue to the stable ground at z=0 instead of stepping to the roof height.
 const rayFilter=b3.b3DefaultQueryFilter();rayFilter.categoryBits=4n;rayFilter.maskBits=1n;
 const aglGround=b3.b3World_CastRayClosest(world,[2.5,0,5],[0,0,-6],rayFilter);
 assert.equal(aglGround.hit,true);assert.ok(Math.abs(5-6*aglGround.fraction)<.03,`building roof contaminated GAME AGL: point=${aglGround.point} fraction=${aglGround.fraction}`);assert.ok(aglGround.normal[2]>.98);
 
-const wallCamera=resolveBox3dCameraPath(b3,world,[1.5,0,1],[3.5,0,1],{queryCategoryBits:8n,terrainCategoryBits:1n,clearanceM:.08});
-assert.equal(wallCamera.collided,true);assert.ok(wallCamera.position[0]>1.5&&wallCamera.position[0]<1.95,`camera crossed building wall: ${JSON.stringify(wallCamera)}`);
-const groundCamera=resolveBox3dCameraPath(b3,world,[0,0,1],[0,0,-1],{queryCategoryBits:8n,terrainCategoryBits:1n,clearanceM:.08});
-assert.equal(groundCamera.collided,true);assert.ok(groundCamera.position[2]>=.075,`camera clipped ground: ${JSON.stringify(groundCamera)}`);
-const clearCamera=resolveBox3dCameraPath(b3,world,[0,0,1],[0,0,2],{queryCategoryBits:8n,terrainCategoryBits:1n,clearanceM:.08});assert.equal(clearCamera.collided,false);assert.deepEqual(clearCamera.position,[0,0,2]);
+// Camera collision is a swept volume, not a center-point ray. This keeps the
+// near frustum out of walls, corners and terrain instead of merely stopping the
+// optical center after it has already entered visible geometry.
+const wallCamera=resolveBox3dCameraPath(b3,world,[1.5,0,1],[3.5,0,1],{queryCategoryBits:8n,terrainCategoryBits:1n});
+assert.equal(wallCamera.collided,true);assert.ok(wallCamera.position[0]>1.5&&wallCamera.position[0]<1.90,`camera volume crossed building wall: ${JSON.stringify(wallCamera)}`);assert.ok(wallCamera.cameraRadiusM>=.10);
+const cornerCamera=resolveBox3dCameraPath(b3,world,[1.5,1.08,1],[3.5,1.08,1],{queryCategoryBits:8n,terrainCategoryBits:1n});
+assert.equal(cornerCamera.collided,true,`camera center ray grazed past the wall edge instead of respecting volume: ${JSON.stringify(cornerCamera)}`);assert.ok(cornerCamera.position[0]<1.95,`camera volume clipped building corner: ${JSON.stringify(cornerCamera)}`);
+const groundCamera=resolveBox3dCameraPath(b3,world,[0,0,1],[0,0,-1],{queryCategoryBits:8n,terrainCategoryBits:1n});
+assert.equal(groundCamera.collided,true);assert.ok(groundCamera.position[2]>=.12,`camera volume clipped ground: ${JSON.stringify(groundCamera)}`);
+const grazingGroundCamera=resolveBox3dCameraPath(b3,world,[0,0,.18],[1,0,.08],{queryCategoryBits:8n,terrainCategoryBits:1n});
+assert.equal(grazingGroundCamera.collided,true);assert.ok(grazingGroundCamera.position[2]>=.118,`camera frustum grazed into terrain: ${JSON.stringify(grazingGroundCamera)}`);
+const clearCamera=resolveBox3dCameraPath(b3,world,[0,0,1],[0,0,2],{queryCategoryBits:8n,terrainCategoryBits:1n});assert.equal(clearCamera.collided,false);assert.deepEqual(clearCamera.position,[0,0,2]);
 
 function makeProbe({position=[0,0,1],velocity=[8,0,0]}={}){
   const bodyDef=b3.b3DefaultBodyDef();bodyDef.type=b3.b3BodyType.b3_dynamicBody;bodyDef.position=position;bodyDef.enableSleep=false;bodyDef.isBullet=true;
@@ -50,8 +49,6 @@ function makeProbe({position=[0,0,1],velocity=[8,0,0]}={}){
 }
 function advance(body,steps=500){for(let index=0;index<steps;index++)b3.b3World_Step(world,.001,4);const position=[0,0,0];b3.b3Body_GetPosition(position,body);return position;}
 
-// Regression: the airframe starts outside the building, while the complete
-// launch building remains physically present. Moving farther away must stay clear.
 const lateral=makeProbe({position:[safeLaunch[0],safeLaunch[1],1],velocity:[0,-4,0]}),lateralPosition=advance(lateral,250);assert.ok(lateralPosition[1]<safeLaunch[1]-.75,`relocated launch is not clear of the building: ${lateralPosition}`);assert.ok(lateralPosition.every(Number.isFinite));b3.b3DestroyBody(lateral);
 
 const blocked=makeProbe({position:[1.5,0,1]}),blockedPosition=advance(blocked);assert.ok(blockedPosition[0]<1.95,`continuous unrelated house wall collision failed: ${blockedPosition}`);assert.ok(blockedPosition.every(Number.isFinite));b3.b3DestroyBody(blocked);
@@ -60,4 +57,4 @@ destroyWorldBuildingCollisionBodies(b3,buildings);assert.equal(b3.b3Body_IsValid
 const clear=makeProbe({position:[1.5,0,1]}),clearPosition=advance(clear);assert.ok(clearPosition[0]>3.5,`destroyed house collider still blocks: ${clearPosition}`);b3.b3DestroyBody(clear);
 b3.b3DestroyWorld(world);
 
-console.log("WORLD Box3D building collision passed: indoor GPS launch relocates beside the building, the full building collider remains active, stable ground-only GAME AGL, camera ground/wall occlusion, unrelated wall contact and collider teardown use real box3d.js 3D shapes.");
+console.log("WORLD Box3D building collision passed: indoor GPS launch relocates beside the building, full colliders remain active, GAME AGL stays ground-only, swept camera volume blocks wall/corner/terrain clipping, unrelated wall contact and teardown use real box3d.js 3D shapes.");

--- a/tests/world_building_collisions_test.mjs
+++ b/tests/world_building_collisions_test.mjs
@@ -8,6 +8,7 @@ import {
   makeBuildingCollisionSnapshot,
   triangulateBuildingFootprints,
 } from "../sim/world_building_collisions.mjs";
+import {resolveBox3dCameraPath} from "../sim/world_building_collision_physics.mjs";
 
 const polygon=(id,coordinates,properties={})=>({id,properties,geometry:{type:"Polygon",coordinates}});
 const square=(x0,y0,x1,y1)=>[[x0,y0],[x1,y0],[x1,y1],[x0,y1],[x0,y0]];
@@ -47,4 +48,15 @@ let courtyardTriangulatorCalls=0;const courtyardPrisms=buildingCollisionPrismsFr
 const snapshot=makeBuildingCollisionSnapshot([polygon("snap",[square(1,2,5,6)],{render_height:11})],{triangulate:fan});
 assert.match(snapshot.hash,/^osm-[0-9a-f]{8}$/);assert.equal(snapshot.footprintCount,1);assert.equal(snapshot.prismCount,1);assert.equal(Object.isFrozen(snapshot),true);
 
-console.log("WORLD building geometry passed: OSM Polygon/MultiPolygon, holes, min/max heights, tile fragments, deterministic hashing and collision budgets are bounded.");
+// Camera occlusion must prefer Box3D's swept mover volume over a center ray.
+// This host contract catches regressions even before the real binding smoke runs.
+let moverCall=null,rayCalls=0;
+const cameraB3={
+  b3DefaultQueryFilter:()=>({categoryBits:0n,maskBits:0n}),
+  b3World_CastMover:(world,origin,mover,translation,filter,callback)=>{moverCall={world,origin:[...origin],mover:{center1:[...mover.center1],center2:[...mover.center2],radius:mover.radius},translation:[...translation],filter:{...filter},callbackResult:callback({})};return .40;},
+  b3World_CastRayClosest:()=>{rayCalls++;return{hit:true,fraction:.9};},
+};
+const cameraSweep=resolveBox3dCameraPath(cameraB3,{id:"world"},[0,0,1],[2,0,1],{queryCategoryBits:8n,terrainCategoryBits:1n,cameraRadiusM:.12,clearanceM:.025});
+assert.ok(moverCall,"camera did not use b3World_CastMover");assert.equal(rayCalls,0,"camera fell back to center ray despite mover support");assert.deepEqual(moverCall.origin,[0,0,1]);assert.deepEqual(moverCall.translation,[2,0,0]);assert.equal(moverCall.mover.radius,.12);assert.equal(moverCall.filter.categoryBits,8n);assert.equal(moverCall.filter.maskBits,1n);assert.equal(cameraSweep.collided,true);assert.ok(cameraSweep.position[0]>.74&&cameraSweep.position[0]<.80,`unexpected swept camera clearance ${JSON.stringify(cameraSweep)}`);
+
+console.log("WORLD building geometry passed: OSM Polygon/MultiPolygon, holes, min/max heights, tile fragments, deterministic hashing, bounded collision budgets and swept camera-volume contract.");

--- a/tests/xbox_gamepad_browser_smoke.mjs
+++ b/tests/xbox_gamepad_browser_smoke.mjs
@@ -27,6 +27,7 @@ await page.evaluateOnNewDocument(()=>{
 
 const pause=ms=>page.evaluate(delay=>new Promise(resolve=>setTimeout(resolve,delay)),ms);
 const setButton=(index,value)=>page.evaluate((i,v)=>globalThis.__xboxTest.setButton(i,v),index,value);
+const pulseButton=async(index,{downMs=70,upMs=95}={})=>{await setButton(index,1);await pause(downMs);await setButton(index,0);await pause(upMs);};
 
 try{
   await page.setViewport({width:844,height:390,deviceScaleFactor:1});
@@ -37,10 +38,23 @@ try{
   const defaultOff=await page.evaluate(()=>{const v=document.querySelector("#viewport"),display=s=>getComputedStyle(document.querySelector(s)).display;return{source:v.dataset.controlSource,enabled:v.dataset.gamepadEnabled,connected:v.dataset.gamepadConnected,left:display("#soloLeft"),right:display("#soloRight"),height:display("#soloClearance"),arm:display("#soloArm"),kill:display("#soloKill"),padConnected:Boolean(navigator.getGamepads?.()[0]?.connected)};});
   if(defaultOff.source!=="touch"||defaultOff.enabled!=="0"||defaultOff.connected!=="0"||defaultOff.left==="none"||defaultOff.right==="none"||defaultOff.height==="none"||defaultOff.arm==="none"||defaultOff.kill==="none"||!defaultOff.padConnected)throw new Error(`Xbox was not safely OFF by default: ${JSON.stringify(defaultOff)}`);
 
-  await page.click("#soloTopbar .phone-settings-button");await page.waitForFunction(()=>document.querySelector(".phone-settings-dialog")?.open,{timeout:3000});
+  // Controller-only settings path: START must work even while Xbox mode is OFF,
+  // D-pad must navigate, A must activate, and B must close without leaking into KILL.
+  await pulseButton(9);await page.waitForFunction(()=>document.querySelector(".phone-settings-dialog")?.open,{timeout:3000});
   const toggleDefault=await page.$eval('.phone-settings-dialog [data-xbox-controller]',input=>input.checked);if(toggleDefault!==false)throw new Error(`Xbox settings toggle is not OFF by default: ${toggleDefault}`);
-  await page.click('.phone-settings-dialog [data-xbox-controller]');await page.click('.phone-settings-dialog [data-close]');
-  await page.waitForFunction(()=>{const v=document.querySelector("#viewport");return v?.dataset.controlSource==="xbox"&&v.dataset.gamepadEnabled==="1"&&v.dataset.gamepadConnected==="1";},{timeout:3000});
+  const nav=await page.evaluate(()=>{const dialog=document.querySelector(".phone-settings-dialog"),target=dialog.querySelector("[data-xbox-controller]"),controls=[...dialog.querySelectorAll('button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])')].filter(element=>{const style=getComputedStyle(element);return style.display!=="none"&&style.visibility!=="hidden"&&element.getClientRects().length>0;}),current=controls.indexOf(document.activeElement),wanted=controls.indexOf(target);return{count:controls.length,current,wanted,active:document.activeElement?.outerHTML?.slice(0,100)||""};});
+  if(nav.count<2||nav.wanted<0)throw new Error(`Xbox menu focus map invalid: ${JSON.stringify(nav)}`);
+  const startIndex=nav.current>=0?nav.current:0,steps=(nav.wanted-startIndex+nav.count)%nav.count;
+  for(let i=0;i<steps;i++)await pulseButton(13,{downMs:55,upMs:70});
+  const focusedXbox=await page.evaluate(()=>document.activeElement===document.querySelector('.phone-settings-dialog [data-xbox-controller]'));if(!focusedXbox)throw new Error(`D-pad did not reach Xbox setting: ${JSON.stringify(nav)}`);
+  await pulseButton(0);const enabledByController=await page.$eval('.phone-settings-dialog [data-xbox-controller]',input=>input.checked);if(!enabledByController)throw new Error("A did not enable Xbox controller setting");
+  const menuSuspended=await page.evaluate(()=>{const display=s=>getComputedStyle(document.querySelector(s)).display,v=document.querySelector("#viewport");return{body:document.body.classList.contains("gamepad-settings-open"),source:v.dataset.controlSource,left:display("#soloLeft"),right:display("#soloRight"),height:display("#soloClearance")};});
+  if(!menuSuspended.body||menuSuspended.left!=="none"||menuSuspended.right!=="none"||menuSuspended.height!=="none")throw new Error(`Controller menu did not own flight input: ${JSON.stringify(menuSuspended)}`);
+  await setButton(1,1);await page.waitForFunction(()=>!document.querySelector(".phone-settings-dialog")?.open,{timeout:3000});await pause(220);
+  const heldB=await page.evaluate(()=>{const v=document.querySelector("#viewport"),display=s=>getComputedStyle(document.querySelector(s)).display;return{source:v.dataset.controlSource,menuGuard:document.body.classList.contains("gamepad-settings-open"),left:display("#soloLeft"),kill:display("#soloKill")};});
+  if(heldB.source==="xbox"||!heldB.menuGuard||heldB.left!=="none"||heldB.kill!=="none")throw new Error(`Held B leaked through menu close into flight controls: ${JSON.stringify(heldB)}`);
+  await setButton(1,0);await page.waitForFunction(()=>{const v=document.querySelector("#viewport");return v?.dataset.controlSource==="xbox"&&v.dataset.gamepadEnabled==="1"&&v.dataset.gamepadConnected==="1"&&!document.body.classList.contains("gamepad-settings-open");},{timeout:3000});
+
   const active=await page.evaluate(()=>{const v=document.querySelector("#viewport"),display=s=>getComputedStyle(document.querySelector(s)).display;return{source:v.dataset.controlSource,connected:v.dataset.gamepadConnected,left:display("#soloLeft"),right:display("#soloRight"),height:display("#soloClearance"),arm:display("#soloArm"),kill:display("#soloKill"),status:document.querySelector("#soloGamepadStatus").hidden,help:document.querySelector("#soloGamepadHelp").hidden,helpText:document.querySelector("#soloGamepadHelp").textContent};});
   if(active.source!=="xbox"||active.connected!=="1"||active.left!=="none"||active.right!=="none"||active.height!=="none"||active.arm!=="none"||active.kill!=="none"||active.status||active.help||!active.helpText.includes("LB+RB FIRE"))throw new Error(`Xbox ON did not remove every touch flight control: ${JSON.stringify(active)}`);
 
@@ -92,5 +106,5 @@ try{
   await page.click("#soloTopbar .phone-settings-button");await page.waitForFunction(()=>document.querySelector(".phone-settings-dialog")?.open,{timeout:3000});await page.click('.phone-settings-dialog [data-xbox-controller]');await page.click('.phone-settings-dialog [data-close]');
   await page.waitForFunction(()=>{const v=document.querySelector("#viewport");return v?.dataset.controlSource==="touch"&&v.dataset.gamepadEnabled==="0"&&getComputedStyle(document.querySelector("#soloLeft")).display!=="none";},{timeout:3000});
 
-  console.log("Xbox browser E2E passed: default OFF, explicit persistent ON/OFF, zero touch HUD while ON/reconnecting, LT down, RT up-only, LB+RS free-look/crosshair, and LB+RB right-shoulder fire.");
+  console.log("Xbox browser E2E passed: controller-only START/D-pad/A/B settings, guarded neutral menu handoff, default OFF, persistent ON/OFF, zero touch HUD while ON/reconnecting, LT down, RT up-only, LB+RS free-look/crosshair, and LB+RB right-shoulder fire.");
 }finally{await browser.close();}


### PR DESCRIPTION
Replace point-ray camera occlusion with a swept spherical camera volume using the bound b3World_CastMover API. Keeps the optical/frustum body physically outside terrain, walls and building corners. Adds real box3d.js regressions for frontal wall collision, edge/corner grazing and terrain grazing. Flight physics/control remain untouched.