### PR TITLE
Verify current WORLD UI without short shell timeout

### DIFF
--- a/.github/workflows/verify-world-ui-current-main-long-timeout.yml
+++ b/.github/workflows/verify-world-ui-current-main-long-timeout.yml
@@ -38,9 +38,35 @@ jobs:
               -s EXPORTED_FUNCTIONS='["_fc_input_buffer","_fc_output_buffer","_fc_input_size","_fc_output_size","_fc_reset","_fc_process","_fc_protocol_version"]' \
               -o generated/flight_core.mjs
 
-      - name: Bundle current runtime and run unchanged WORLD UI gate
+      - name: Bundle current runtime and run current WORLD UI contract
         run: |
           set -euxo pipefail
+          # main intentionally changed combat from touch-coordinate aim to fixed-center aim,
+          # but this older aggregate WORLD smoke still carries the pre-change assertion.
+          # Patch only that stale assertion in the verifier; runtime stays untouched.
+          python3 - <<'PY'
+          from pathlib import Path
+          path=Path('tests/real_world_ui_smoke.mjs')
+          source=path.read_text()
+          replacements=[
+              ('// Touch coordinate is the aim coordinate. Drag moves that coordinate 1:1 while\n  // automatic fire continues until pointerup. No virtual stick or reticle exists.',
+               '// Touch holds the trigger while current combat aim remains fixed at viewport center.\n  // Drag must sustain fire without changing that fixed-center shot direction.'),
+              ('expectedX=ex-r.left,expectedY=ey-r.top,aimUi=',
+               'expectedX=v.clientWidth*.5,expectedY=v.clientHeight*.5,mode=v.dataset.fireAimMode,aimUi='),
+              ('return{before,during,writes0,writes,worldDecals,aimX,aimY,expectedX,expectedY,aimUi,pool:',
+               'return{before,during,writes0,writes,worldDecals,aimX,aimY,expectedX,expectedY,mode,aimUi,pool:'),
+              ('dragFire.worldDecals<1||dragFire.aimUi||Math.abs',
+               'dragFire.worldDecals<1||dragFire.mode!=="center-fixed"||dragFire.aimUi||Math.abs'),
+              ('WORLD touch coordinate did not map 1:1 to sustained fire/decal aim:',
+               'WORLD fixed-center sustained fire/decal aim failed:'),
+              ('1:1 touch-coordinate firing,', 'fixed-center sustained firing,'),
+          ]
+          for old,new in replacements:
+              count=source.count(old)
+              assert count==1, f'stale WORLD fire contract patch expected one match, got {count}: {old[:80]}'
+              source=source.replace(old,new,1)
+          path.write_text(source)
+          PY
           node --check sim/real_world_bootstrap.mjs
           node --check tests/real_world_ui_smoke.mjs
           ./node_modules/.bin/esbuild sim/real_world_bootstrap.mjs \

--- a/.github/workflows/verify-world-ui-current-main-long-timeout.yml
+++ b/.github/workflows/verify-world-ui-current-main-long-timeout.yml
@@ -1,0 +1,66 @@
+name: Verify WORLD UI current main
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install browser build dependencies
+        run: |
+          set -euxo pipefail
+          BUILD_DIR=/tmp/arondight-world-ui-current
+          rm -rf "$BUILD_DIR"
+          mkdir -p "$BUILD_DIR"
+          cd "$BUILD_DIR"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund \
+            three@0.185.1 box3d.js@0.1.1 maplibre-gl@5.24.0 esbuild@0.25.8 puppeteer-core@24.16.0 mqtt@5.15.2 nostr-tools@2.24.1 \
+            qrcode-generator@1.4.4 jsqr@1.4.0 trystero@0.25.3 @trystero-p2p/mqtt@0.25.3 @trystero-p2p/torrent@0.25.3
+          ln -s "$BUILD_DIR/node_modules" "$GITHUB_WORKSPACE/node_modules"
+
+      - name: Build exact shared WASM core
+        run: |
+          set -euxo pipefail
+          mkdir -p generated
+          docker run --rm -v "$PWD:/src" -w /src emscripten/emsdk:4.0.10 \
+            em++ sim/Arondight45_DroneFC_SIL_WASM.cpp -std=c++17 -O3 \
+              -s MODULARIZE=1 -s EXPORT_ES6=1 -s ENVIRONMENT='web' \
+              -s INVOKE_RUN=0 -s EXIT_RUNTIME=0 -s FILESYSTEM=0 -s SINGLE_FILE=1 \
+              -s ALLOW_MEMORY_GROWTH=0 -s INITIAL_MEMORY=16777216 \
+              -s EXPORTED_RUNTIME_METHODS='["HEAPU8"]' \
+              -s EXPORTED_FUNCTIONS='["_fc_input_buffer","_fc_output_buffer","_fc_input_size","_fc_output_size","_fc_reset","_fc_process","_fc_protocol_version"]' \
+              -o generated/flight_core.mjs
+
+      - name: Bundle current runtime and run unchanged WORLD UI gate
+        run: |
+          set -euxo pipefail
+          node --check sim/real_world_bootstrap.mjs
+          node --check tests/real_world_ui_smoke.mjs
+          ./node_modules/.bin/esbuild sim/real_world_bootstrap.mjs \
+            --bundle --format=esm --platform=browser --target=es2022 --minify \
+            --alias:box3d.js/dist/box3d.inline.mjs=box3d.js/inline \
+            --outfile=/tmp/arondight-world-ui-current.bundle.mjs
+          python3 - <<'PY'
+          from pathlib import Path
+          path=Path('drone_simulator.html')
+          html=path.read_text()
+          marker='<script type="module" src="./sim/real_world_bootstrap.mjs"></script>'
+          assert marker in html, 'source WORLD bootstrap tag missing'
+          bundle=Path('/tmp/arondight-world-ui-current.bundle.mjs').read_text().replace('</script','<\\/script')
+          path.write_text(html.replace(marker,'<script type="module">\n'+bundle+'\n</script>'))
+          PY
+          CHROME_BIN="$(command -v google-chrome || command -v chromium || command -v chromium-browser || true)"
+          test -n "$CHROME_BIN"
+          python3 -m http.server 4174 --bind 127.0.0.1 >/tmp/world-ui-current-http.log 2>&1 &
+          HTTP_PID=$!
+          cleanup(){ kill "$HTTP_PID" 2>/dev/null || true; rm -f node_modules; }
+          trap cleanup EXIT
+          sleep 1
+          CHROME_BIN="$CHROME_BIN" node tests/real_world_ui_smoke.mjs http://127.0.0.1:4174


### PR DESCRIPTION
Verification-only replacement for the stale WORLD UI browser-gate drafts, based directly on current `main` (`0c172e09`).

Findings:
- #50's 150 s shell timeout was a real blocker, but not the only one.
- With the short timeout removed, current `main` reached the aggregate WORLD smoke in ~21 s and failed on a stale assertion: `real_world_ui_smoke.mjs` still expected 1:1 touch-coordinate aiming.
- Current runtime intentionally uses `fireAimMode="center-fixed"`, and the current dedicated `combat_center_fire_browser_smoke.mjs` already asserts that contract.

This verifier therefore:
- uses current imagery-only WORLD behavior from `main`
- leaves production runtime untouched
- uses only a 20 minute job-level timeout (no shell `timeout 150s`)
- patches only the stale aggregate test expectation from touch-coordinate aim to current fixed-center sustained fire
- changes no DEM/Mapterhorn behavior and uses no pause/1 kHz plant workaround

Result: run #2 is GREEN. The full WORLD UI E2E completed with GPS WORLD startup, imagery/minimap/settings/camera checks, fixed-center sustained firing, and recycled 32-mesh decal pool.

Clean permanent follow-up: update the stale fire assertion in `tests/real_world_ui_smoke.mjs` to the already-established center-fixed contract, then remove this temporary verifier workflow.