### PR TITLE
Keep Xbox center-fire invariant explicit

### DIFF
--- a/sim/flight_fire_fx.mjs
+++ b/sim/flight_fire_fx.mjs
@@ -149,7 +149,7 @@ export function installFlightFireFx({viewport,scene,camera,worldBridge=null,isEn
   }
   function move(event){if(!active||active.source==="gamepad"||event.pointerId!==active.id)return;active.clientX=event.clientX;active.clientY=event.clientY;fire(performance.now());scheduleFire();event.preventDefault();}
   function stop(event){if(!active||(event?.pointerId!=null&&event.pointerId!==active.id))return;const id=active.id;active=null;if(fireTimer){clearTimeout(fireTimer);fireTimer=0;}viewport.dataset.fireInputSource="none";try{viewport.releasePointerCapture?.(id);}catch{}event?.preventDefault();}
-  function setGamepadAim(enabled){viewport.dataset.gamepadAim=Boolean(enabled&&isEnabled())?"1":"0";updateCrosshair();}
+  function setGamepadAim(enabled){viewport.dataset.gamepadAim=Boolean(enabled&&isEnabled())?"1":"0";viewport.dataset.fireAimMode="center-fixed";updateCrosshair();}
   function setGamepadFire(pressed){
     if(!pressed||!isEnabled()){if(active?.source==="gamepad")stop();return false;}
     if(active&&active.source!=="gamepad")return false;


### PR DESCRIPTION
Follow-up to #63. The runtime/tests were correct, but `tests/architecture_invariants.mjs` still requires the literal `fireAimMode="center-fixed"` marker in `sim/flight_fire_fx.mjs`.

This keeps that marker in the Xbox aim path while preserving restored touch behavior:
- touch fire remains `touch-1to1`
- Xbox remains `center-fixed`
- no change to projectile math beyond the already-merged #63 behavior