### PR TITLE
Move Safari multiplayer gameplay to direct P2P UDP

### DIFF
--- a/sim/nostr_data_relay.mjs
+++ b/sim/nostr_data_relay.mjs
@@ -8,13 +8,18 @@ const RELAYS=[
   "wss://relay.primal.net"
 ];
 const EVENT_KIND=25045;
-const PROTOCOL_VERSION=1;
+const PROTOCOL_VERSION=3;
 const HELLO_MS=1000;
 const HEARTBEAT_MS=5000;
-const PEER_TIMEOUT_MS=16000;
 const CONNECT_ERROR_MS=12000;
+const DISCONNECT_GRACE_MS=4500;
 const MAX_PACKET_BYTES=32768;
 const MAX_SEEN=2048;
+const POSE_BUFFER_LIMIT_BYTES=65536;
+const STUN_ICE_SERVERS=[
+  {urls:["stun:stun.cloudflare.com:3478","stun:stun.cloudflare.com:53"]},
+  {urls:"stun:stun.l.google.com:19302"}
+];
 const rooms=new Set();
 const relayStates=new Map(RELAYS.map(url=>[url,{readyState:0,error:""}]));
 let pool=null;
@@ -24,103 +29,91 @@ function clean(value){return String(value||"").replace(/[^a-zA-Z0-9_.-]/g,"_").s
 function randomId(){try{return globalThis.crypto?.randomUUID?.().replaceAll("-","")||randomBytes();}catch{return randomBytes();}}
 function randomBytes(){const bytes=new Uint8Array(16);try{globalThis.crypto?.getRandomValues?.(bytes);}catch{for(let i=0;i<bytes.length;i++)bytes[i]=Math.floor(Math.random()*256);}return [...bytes].map(v=>v.toString(16).padStart(2,"0")).join("");}
 function packetId(){return `${Date.now().toString(36)}-${randomId().slice(0,12)}`;}
-function emitNetwork(stage,detail={}){try{if(typeof globalThis.dispatchEvent==="function"&&typeof globalThis.CustomEvent==="function")globalThis.dispatchEvent(new CustomEvent("arondight45:vs-network",{detail:{at:new Date().toISOString(),stage,transport:"NostrRelay",...detail}}));}catch{}}
+function errorText(error){return String(error?.message||error||"unknown error");}
+function emitNetwork(stage,detail={}){try{if(typeof globalThis.dispatchEvent==="function"&&typeof globalThis.CustomEvent==="function")globalThis.dispatchEvent(new CustomEvent("arondight45:vs-network",{detail:{at:new Date().toISOString(),stage,transport:"DirectP2PUDP",...detail}}));}catch{}}
 function statusObject(url){return relayStates.get(url)||{readyState:3,error:"missing"};}
-function refreshRelayStates(){
-  try{const status=pool?.listConnectionStatus?.();if(status)for(const url of RELAYS){const connected=Boolean(status.get(url)||status.get(`${url}/`));const state=statusObject(url);if(connected){state.readyState=1;state.error="";}else if(state.readyState===1)state.readyState=0;}}catch{}
-}
+function refreshRelayStates(){try{const status=pool?.listConnectionStatus?.();if(status)for(const url of RELAYS){const connected=Boolean(status.get(url)||status.get(`${url}/`)),state=statusObject(url);if(connected){state.readyState=1;state.error="";}else if(state.readyState===1)state.readyState=0;}}catch{}}
 export function getRelaySockets(){refreshRelayStates();return Object.fromEntries(RELAYS.map(url=>[url,{...statusObject(url)}]));}
 function ensurePool(){
   if(pool)return pool;
   pool=new SimplePool({enablePing:true,enableReconnect:true});
-  pool.onRelayConnectionSuccess=url=>{const state=statusObject(String(url).replace(/\/$/,""));state.readyState=1;state.error="";emitNetwork("nostr-relay-open",{relay:String(url)});};
-  pool.onRelayConnectionFailure=url=>{const normalized=String(url).replace(/\/$/,""),state=statusObject(normalized);state.readyState=3;state.error="connection failure";emitNetwork("nostr-relay-error",{relay:String(url),error:state.error});};
+  pool.onRelayConnectionSuccess=url=>{const normalized=String(url).replace(/\/$/,""),state=statusObject(normalized);state.readyState=1;state.error="";emitNetwork("signal-relay-open",{relay:normalized});};
+  pool.onRelayConnectionFailure=url=>{const normalized=String(url).replace(/\/$/,""),state=statusObject(normalized);state.readyState=3;state.error="connection failure";emitNetwork("signal-relay-error",{relay:normalized,error:state.error});};
   signerKey=generateSecretKey();
   return pool;
 }
 function closePoolIfIdle(){if(rooms.size||!pool)return;try{pool.close(RELAYS);}catch{}try{pool.destroy?.();}catch{}pool=null;signerKey=null;for(const state of relayStates.values()){state.readyState=3;state.error="";}}
-function bytesToBase64(bytes){let raw="";for(let i=0;i<bytes.length;i++)raw+=String.fromCharCode(bytes[i]);return btoa(raw);}
-function base64ToBytes(value){const raw=atob(String(value||"")),out=new Uint8Array(raw.length);for(let i=0;i<raw.length;i++)out[i]=raw.charCodeAt(i);return out;}
-async function generateIdentity(){
-  const subtle=globalThis.crypto?.subtle;if(!subtle)throw Error("WebCrypto unavailable for Nostr VS relay encryption");
-  const pair=await subtle.generateKey({name:"ECDH",namedCurve:"P-256"},true,["deriveKey"]),publicJwk=await subtle.exportKey("jwk",pair.publicKey);return{pair,publicJwk};
-}
-async function derivePeerKey(privateKey,publicJwk){
-  const subtle=globalThis.crypto?.subtle;if(!subtle)throw Error("WebCrypto unavailable for Nostr VS relay encryption");
-  const peerPublic=await subtle.importKey("jwk",publicJwk,{name:"ECDH",namedCurve:"P-256"},false,[]);
-  return subtle.deriveKey({name:"ECDH",public:peerPublic},privateKey,{name:"AES-GCM",length:256},false,["encrypt","decrypt"]);
-}
-async function seal(key,value){const iv=globalThis.crypto.getRandomValues(new Uint8Array(12)),plain=new TextEncoder().encode(JSON.stringify(value)),cipher=new Uint8Array(await globalThis.crypto.subtle.encrypt({name:"AES-GCM",iv},key,plain));return{iv:bytesToBase64(iv),box:bytesToBase64(cipher)};}
-async function openSealed(key,iv,box){const plain=await globalThis.crypto.subtle.decrypt({name:"AES-GCM",iv:base64ToBytes(iv)},key,base64ToBytes(box));return JSON.parse(new TextDecoder().decode(plain));}
 function parseEvent(event){try{const text=String(event?.content||"");if(text.length>MAX_PACKET_BYTES)return null;const value=JSON.parse(text);return value&&value.v===PROTOCOL_VERSION&&typeof value.id==="string"&&typeof value.kind==="string"?value:null;}catch{return null;}}
-function fakePeer(){return{connectionState:"connected",iceConnectionState:"nostr-relay-e2ee",iceGatheringState:"complete",signalingState:"stable",addEventListener(){},getStats:async()=>new Map()};}
+function candidateProtocol(candidate){const direct=String(candidate?.protocol||"").toLowerCase();if(direct)return direct;const parts=String(candidate?.candidate||"").trim().split(/\s+/);return String(parts[2]||"").toLowerCase();}
+function rtcCtor(config){return config?.RTCPeerConnectionCtor||globalThis.RTCPeerConnection;}
+function channelOpen(channel){return Boolean(channel&&channel.readyState==="open");}
+function safeParse(text){try{return JSON.parse(String(text));}catch{return null;}}
+function peerSnapshot(pc,isHost){if(!pc)return null;pc.__a45HostAuthority=Boolean(isHost);pc.__a45Transport="direct-p2p-udp";return pc;}
 
-class NostrRelayRoom{
+class DirectUdpRoom{
   constructor(config,roomId,callbacks={}){
-    this.appId=clean(config?.appId||"app");this.roomId=clean(roomId);this.tag=`a45-vs-${this.appId}-${this.roomId}`;
-    this.id=randomId();this.actions=new Map();this.peers=new Set();this.peerKeys=new Map();this.peerPublicKeys=new Map();this.peerSeen=new Map();this.seen=new Set();this.pendingPings=new Map();this.closed=false;this._onPeerJoin=null;this._onPeerLeave=null;this.onJoinError=callbacks?.onJoinError;this.preferredRelay="";
-    this.cryptoReady=generateIdentity().then(identity=>{this.identity=identity;return identity;}).catch(error=>{this.onJoinError?.({peerId:"",error});throw error;});
+    this.config=config||{};this.appId=clean(config?.appId||"app");this.roomId=clean(roomId);this.tag=`a45-vs-p2p-${this.appId}-${this.roomId}`;
+    this.id=randomId();this.peerId="";this.isHost=false;this.pc=null;this.poseChannel=null;this.controlChannel=null;this.actions=new Map();this.seen=new Set();this.pendingCandidates=[];this.pendingPings=new Map();this.closed=false;this.ready=false;this.offerStarted=false;this.restartInFlight=false;this._onPeerJoin=null;this._onPeerLeave=null;this.onJoinError=callbacks?.onJoinError;this.disconnectTimer=0;this.errorTimer=0;this.helloTimer=0;this.heartbeatTimer=0;
+    const RTC=rtcCtor(this.config);if(typeof RTC!=="function")throw Error("Direct UDP WebRTC unavailable");
     const p=ensurePool();rooms.add(this);
-    this.subscription=p.subscribe(RELAYS,{kinds:[EVENT_KIND],"#t":[this.tag],since:Math.floor(Date.now()/1000)-5},{
-      onevent:event=>{const packet=parseEvent(event);if(packet)this._receive(packet);},
-      onclose:items=>{for(const item of items||[]){const url=String(item?.url||"").replace(/\/$/,""),state=statusObject(url);state.readyState=3;state.error=String(item?.reason||"subscription closed");emitNetwork("nostr-relay-subscription-close",{relay:url,error:state.error,roomId:this.roomId});}}
-    });
-    this.helloTimer=setInterval(()=>this._announce(),HELLO_MS);this.heartbeatTimer=setInterval(()=>this._announce(),HEARTBEAT_MS);this.sweepTimer=setInterval(()=>this._sweepPeers(),5000);
-    this.errorTimer=setTimeout(()=>{if(!this.closed&&!this.peers.size&&!Object.values(getRelaySockets()).some(state=>state.readyState===1)){const error=Error("Nostr data relays unavailable");emitNetwork("nostr-relays-unavailable",{roomId:this.roomId,relays:getRelaySockets()});this.onJoinError?.({peerId:"",error});}},CONNECT_ERROR_MS);
+    this.subscription=p.subscribe(RELAYS,{kinds:[EVENT_KIND],"#t":[this.tag],since:Math.floor(Date.now()/1000)-5},{onevent:event=>{const packet=parseEvent(event);if(packet)this._receiveSignal(packet);},onclose:items=>{for(const item of items||[]){const url=String(item?.url||"").replace(/\/$/,""),state=statusObject(url);state.readyState=3;state.error=String(item?.reason||"subscription closed");emitNetwork("signal-subscription-close",{relay:url,error:state.error,roomId:this.roomId});}}});
+    this.helloTimer=setInterval(()=>this._announce(),HELLO_MS);this.heartbeatTimer=setInterval(()=>{if(!this.ready)this._announce();},HEARTBEAT_MS);
+    this.errorTimer=setTimeout(()=>{if(!this.closed&&!this.ready){const error=Error(this.peerId?"Direct UDP peer connection timed out":"Direct UDP peer not found");emitNetwork("direct-udp-timeout",{roomId:this.roomId,peerId:this.peerId});this.onJoinError?.({peerId:this.peerId,error});}},CONNECT_ERROR_MS);
     queueMicrotask(()=>this._announce());
   }
-  set onPeerJoin(fn){this._onPeerJoin=typeof fn==="function"?fn:null;if(this._onPeerJoin)for(const peerId of this.peers)queueMicrotask(()=>this._onPeerJoin?.(peerId));}
+  set onPeerJoin(fn){this._onPeerJoin=typeof fn==="function"?fn:null;if(this._onPeerJoin&&this.ready&&this.peerId)queueMicrotask(()=>this._onPeerJoin?.(this.peerId));}
   get onPeerJoin(){return this._onPeerJoin;}
   set onPeerLeave(fn){this._onPeerLeave=typeof fn==="function"?fn:null;}
   get onPeerLeave(){return this._onPeerLeave;}
   _base(kind,target=""){return{v:PROTOCOL_VERSION,kind,id:this.id,msgId:packetId(),target:String(target||""),ts:Date.now()};}
   _remember(msgId){if(!msgId||this.seen.has(msgId))return false;this.seen.add(msgId);if(this.seen.size>MAX_SEEN)this.seen.delete(this.seen.values().next().value);return true;}
-  _touch(peerId){if(peerId)this.peerSeen.set(peerId,Date.now());}
-  _sweepPeers(){const now=Date.now();for(const peerId of [...this.peers])if(now-(this.peerSeen.get(peerId)||0)>PEER_TIMEOUT_MS){this.peers.delete(peerId);this.peerSeen.delete(peerId);this.peerKeys.delete(peerId);this.peerPublicKeys.delete(peerId);this._onPeerLeave?.(peerId);emitNetwork("nostr-relay-peer-timeout",{peerId,roomId:this.roomId});}}
-  async _publish(packet,fast=false){
-    if(this.closed)throw Error("Nostr data relay room closed");
-    const text=JSON.stringify(packet);if(text.length>MAX_PACKET_BYTES)throw Error("Nostr VS relay packet too large");
+  async _publishSignal(packet){
+    if(this.closed)throw Error("Direct UDP room closed");const text=JSON.stringify(packet);if(text.length>MAX_PACKET_BYTES)throw Error("Direct UDP signaling packet too large");
     const p=ensurePool(),event=finalizeEvent({kind:EVENT_KIND,created_at:Math.floor(Date.now()/1000),tags:[["t",this.tag],["expiration",String(Math.floor(Date.now()/1000)+30)]],content:text},signerKey);
-    const targets=fast&&this.preferredRelay?[this.preferredRelay]:RELAYS;
-    const attempts=targets.map(url=>p.publish([url],event,{maxWait:2500})[0].then(()=>{const normalized=url.replace(/\/$/,""),state=statusObject(normalized);state.readyState=1;state.error="";this.preferredRelay=normalized;return normalized;}).catch(error=>{const normalized=url.replace(/\/$/,""),state=statusObject(normalized);state.readyState=3;state.error=String(error?.message||error||"publish failed");throw error;}));
-    try{return await Promise.any(attempts);}catch(error){if(fast&&this.preferredRelay){this.preferredRelay="";return this._publish(packet,false);}throw error;}
+    const attempts=RELAYS.map(url=>p.publish([url],event,{maxWait:2500})[0].then(()=>{const normalized=url.replace(/\/$/,""),state=statusObject(normalized);state.readyState=1;state.error="";return normalized;}).catch(error=>{const normalized=url.replace(/\/$/,""),state=statusObject(normalized);state.readyState=3;state.error=errorText(error);throw error;}));
+    return Promise.any(attempts);
   }
-  _announce(){if(this.closed)return;this.cryptoReady.then(()=>this._publish({...this._base("hello"),key:this.identity.publicJwk},false)).catch(()=>{});}
-  async _adopt(peerId,publicJwk){
-    if(!peerId||peerId===this.id)return;this._touch(peerId);
-    if(this.peers.has(peerId)){if(publicJwk&&!this.peerPublicKeys.has(peerId))this.peerPublicKeys.set(peerId,publicJwk);return;}
-    if(!publicJwk||typeof publicJwk!=="object")return;await this.cryptoReady;
-    const key=await derivePeerKey(this.identity.pair.privateKey,publicJwk);if(this.closed)return;
-    this.peerPublicKeys.set(peerId,publicJwk);this.peerKeys.set(peerId,key);this.peers.add(peerId);this._touch(peerId);clearTimeout(this.errorTimer);this._onPeerJoin?.(peerId);emitNetwork("nostr-relay-peer-join",{peerId,roomId:this.roomId,relay:this.preferredRelay});
-    this._publish({...this._base("hello",peerId),key:this.identity.publicJwk},false).catch(()=>{});
+  _announce(){if(this.closed||this.ready)return;this._publishSignal(this._base("hello")).catch(()=>{});}
+  _receiveSignal(packet){this._receiveSignalAsync(packet).catch(error=>{emitNetwork("signal-handle-error",{roomId:this.roomId,error:errorText(error)});this.onJoinError?.({peerId:String(packet?.id||""),error});});}
+  async _receiveSignalAsync(packet){
+    if(this.closed||packet.id===this.id||!this._remember(packet.msgId))return;if(packet.target&&packet.target!==this.id)return;
+    if(packet.kind==="hello"){
+      if(this.peerId&&packet.id!==this.peerId)return;
+      if(!this.peerId){this.peerId=packet.id;this.isHost=this.id<packet.id;emitNetwork("authority-elected",{roomId:this.roomId,peerId:this.peerId,role:this.isHost?"host":"client"});await this._ensureRtc();}
+      if(this.isHost&&!this.offerStarted)await this._startOffer(false);return;
+    }
+    if(packet.id!==this.peerId)return;if(packet.kind==="bye"){this._peerGone("signal-bye");return;}await this._ensureRtc();
+    if(packet.kind==="description"){
+      const description=packet.description;if(!description||typeof description.type!=="string"||typeof description.sdp!=="string")return;
+      await this.pc.setRemoteDescription(description);await this._flushCandidates();
+      if(description.type==="offer"){const answer=await this.pc.createAnswer();await this.pc.setLocalDescription(answer);await this._publishSignal({...this._base("description",this.peerId),description:{type:this.pc.localDescription.type,sdp:this.pc.localDescription.sdp}});}return;
+    }
+    if(packet.kind==="candidate"){const candidate=packet.candidate;if(!candidate||candidateProtocol(candidate)!=="udp")return;if(this.pc.remoteDescription)await this.pc.addIceCandidate(candidate);else this.pendingCandidates.push(candidate);}
   }
-  _receive(packet){this._receiveAsync(packet).catch(error=>this.onJoinError?.({peerId:String(packet?.id||""),error}));}
-  async _receiveAsync(packet){
-    if(this.closed||packet.id===this.id||!this._remember(packet.msgId))return;if(packet.target&&packet.target!==this.id)return;this._touch(packet.id);
-    if(packet.kind==="hello"){await this._adopt(packet.id,packet.key);return;}
-    if(packet.kind==="bye"){if(this.peers.delete(packet.id))this._onPeerLeave?.(packet.id);this.peerSeen.delete(packet.id);this.peerKeys.delete(packet.id);this.peerPublicKeys.delete(packet.id);return;}
-    if(!this.peers.has(packet.id))return;
-    if(packet.kind==="sealed"){
-      const key=this.peerKeys.get(packet.id);if(!key)return;const payload=await openSealed(key,packet.iv,packet.box);this.actions.get(String(payload?.action||""))?.onMessage?.(payload?.data,{peerId:packet.id});
-    }else if(packet.kind==="ping")this._publish({...this._base("pong",packet.id),nonce:packet.nonce},false).catch(()=>{});
-    else if(packet.kind==="pong"){const pending=this.pendingPings.get(packet.nonce);if(pending){this.pendingPings.delete(packet.nonce);pending.resolve(performance.now()-pending.started);}}
+  async _ensureRtc(){
+    if(this.pc)return;const RTC=rtcCtor(this.config),pc=new RTC({iceServers:STUN_ICE_SERVERS,iceTransportPolicy:"all",bundlePolicy:"max-bundle",rtcpMuxPolicy:"require",iceCandidatePoolSize:2});this.pc=pc;
+    const pose=pc.createDataChannel("pose",{negotiated:true,id:0,ordered:false,maxRetransmits:0});
+    const control=pc.createDataChannel("control",{negotiated:true,id:1,ordered:true});
+    pose.binaryType="arraybuffer";control.binaryType="arraybuffer";pose.bufferedAmountLowThreshold=0;control.bufferedAmountLowThreshold=0;this.poseChannel=pose;this.controlChannel=control;
+    pose.onopen=()=>this._maybeReady();control.onopen=()=>this._maybeReady();pose.onclose=()=>this._channelClosed("pose");control.onclose=()=>this._channelClosed("control");pose.onerror=()=>emitNetwork("pose-channel-error",{roomId:this.roomId,peerId:this.peerId});control.onerror=()=>emitNetwork("control-channel-error",{roomId:this.roomId,peerId:this.peerId});pose.onmessage=event=>this._receiveGameplay("pose",event.data);control.onmessage=event=>this._receiveControl(event.data);
+    pc.onicecandidate=event=>{const candidate=event.candidate;if(!candidate)return;if(candidateProtocol(candidate)!=="udp"){emitNetwork("ice-candidate-rejected",{roomId:this.roomId,protocol:candidateProtocol(candidate)||"unknown"});return;}const json=typeof candidate.toJSON==="function"?candidate.toJSON():{candidate:candidate.candidate,sdpMid:candidate.sdpMid,sdpMLineIndex:candidate.sdpMLineIndex,usernameFragment:candidate.usernameFragment};this._publishSignal({...this._base("candidate",this.peerId),candidate:json}).catch(()=>{});};
+    pc.onconnectionstatechange=()=>this._connectionChanged();pc.oniceconnectionstatechange=()=>this._connectionChanged();
   }
-  async _sendAction(action,data,target){
-    const targets=target?[String(target)]:[...this.peers];if(!targets.length)throw Error("Nostr VS relay peer unavailable");
-    const results=await Promise.allSettled(targets.map(async peerId=>{const key=this.peerKeys.get(peerId);if(!key)throw Error("Nostr VS relay encryption key unavailable");const encrypted=await seal(key,{action,data});return this._publish({...this._base("sealed",peerId),fast:action==="pose",...encrypted},action==="pose");}));
-    if(results.every(result=>result.status==="rejected"))throw results[0].reason||Error("Nostr VS relay encrypted send failed");
-  }
+  async _startOffer(iceRestart=false){if(this.closed||!this.pc||!this.peerId)return;if(!iceRestart)this.offerStarted=true;const offer=await this.pc.createOffer(iceRestart?{iceRestart:true}:{});await this.pc.setLocalDescription(offer);await this._publishSignal({...this._base("description",this.peerId),description:{type:this.pc.localDescription.type,sdp:this.pc.localDescription.sdp}});emitNetwork(iceRestart?"ice-restart-offer":"direct-udp-offer",{roomId:this.roomId,peerId:this.peerId,role:this.isHost?"host":"client"});}
+  async _flushCandidates(){if(!this.pc?.remoteDescription)return;const queue=this.pendingCandidates.splice(0);for(const candidate of queue)try{await this.pc.addIceCandidate(candidate);}catch(error){emitNetwork("ice-candidate-add-error",{error:errorText(error)});}}
+  _maybeReady(){if(this.closed||this.ready||!this.peerId||!channelOpen(this.poseChannel)||!channelOpen(this.controlChannel))return;this.ready=true;clearTimeout(this.errorTimer);this.errorTimer=0;clearInterval(this.helloTimer);clearInterval(this.heartbeatTimer);this.helloTimer=0;this.heartbeatTimer=0;emitNetwork("direct-udp-ready",{roomId:this.roomId,peerId:this.peerId,role:this.isHost?"host":"client",pose:{ordered:this.poseChannel.ordered,maxRetransmits:this.poseChannel.maxRetransmits},control:{ordered:this.controlChannel.ordered,maxRetransmits:this.controlChannel.maxRetransmits}});this._onPeerJoin?.(this.peerId);}
+  _connectionChanged(){if(this.closed||!this.pc)return;const state=String(this.pc.connectionState||this.pc.iceConnectionState||"");emitNetwork("direct-udp-state",{roomId:this.roomId,peerId:this.peerId,state,iceState:String(this.pc.iceConnectionState||"")});if(state==="connected"){clearTimeout(this.disconnectTimer);this.disconnectTimer=0;this.restartInFlight=false;this._maybeReady();return;}if(state==="failed"){this._restartOrLeave("failed");return;}if(state==="disconnected"&&!this.disconnectTimer)this.disconnectTimer=setTimeout(()=>{this.disconnectTimer=0;this._restartOrLeave("disconnected");},DISCONNECT_GRACE_MS);if(state==="closed")this._peerGone("closed");}
+  _restartOrLeave(reason){if(this.closed||!this.peerId)return;if(this.isHost&&!this.restartInFlight){this.restartInFlight=true;Promise.resolve(this._startOffer(true)).catch(error=>{emitNetwork("ice-restart-error",{error:errorText(error)});this._peerGone(reason);}).finally(()=>{setTimeout(()=>{this.restartInFlight=false;},2000);});return;}if(!this.isHost)this._peerGone(reason);}
+  _channelClosed(channel){if(this.closed)return;emitNetwork("direct-udp-channel-close",{roomId:this.roomId,peerId:this.peerId,channel});if(this.ready)this._peerGone(`${channel}-closed`);}
+  _peerGone(reason){if(this.closed)return;const peerId=this.peerId,wasReady=this.ready;this.ready=false;this.peerId="";this.isHost=false;this.offerStarted=false;clearTimeout(this.disconnectTimer);this.disconnectTimer=0;try{this.pc?.close?.();}catch{}this.pc=null;this.poseChannel=null;this.controlChannel=null;this.pendingCandidates=[];for(const pending of this.pendingPings.values())pending.reject?.(Error("Direct UDP peer left"));this.pendingPings.clear();if(wasReady&&peerId)this._onPeerLeave?.(peerId);emitNetwork("direct-udp-peer-left",{roomId:this.roomId,peerId,reason});if(!this.closed){clearInterval(this.helloTimer);clearInterval(this.heartbeatTimer);this.helloTimer=setInterval(()=>this._announce(),HELLO_MS);this.heartbeatTimer=setInterval(()=>{if(!this.ready)this._announce();},HEARTBEAT_MS);this._announce();}}
+  _receiveGameplay(action,data){if(!this.ready||!this.peerId)return;const payload=safeParse(data);if(!payload)return;this.actions.get(action)?.onMessage?.(payload,{peerId:this.peerId});}
+  _receiveControl(data){if(!this.ready||!this.peerId)return;const packet=safeParse(data);if(!packet||typeof packet.a!=="string")return;if(packet.a==="__ping"){this._sendControl({a:"__pong",n:packet.n}).catch(()=>{});return;}if(packet.a==="__pong"){const pending=this.pendingPings.get(packet.n);if(pending){this.pendingPings.delete(packet.n);pending.resolve(performance.now()-pending.started);}return;}this.actions.get(packet.a)?.onMessage?.(packet.d,{peerId:this.peerId});}
+  _sendControl(packet){if(!channelOpen(this.controlChannel))return Promise.reject(Error("Direct UDP reliable channel unavailable"));try{this.controlChannel.send(JSON.stringify(packet));return Promise.resolve();}catch(error){return Promise.reject(error);}}
+  _sendAction(action,data,target){if(!this.ready||!this.peerId)return Promise.reject(Error("Direct UDP peer unavailable"));if(target&&String(target)!==this.peerId)return Promise.reject(Error("Direct UDP target peer unavailable"));if(action==="pose"){if(!channelOpen(this.poseChannel))return Promise.reject(Error("Direct UDP pose channel unavailable"));if(this.poseChannel.bufferedAmount>POSE_BUFFER_LIMIT_BYTES){emitNetwork("pose-drop-backpressure",{roomId:this.roomId,peerId:this.peerId,bufferedAmount:this.poseChannel.bufferedAmount});return Promise.resolve();}try{this.poseChannel.send(JSON.stringify(data));return Promise.resolve();}catch(error){return Promise.reject(error);}}return this._sendControl({a:action,d:data});}
   makeAction(name){const key=String(name||"");const action={onMessage:null,send:(data,{target}={})=>this._sendAction(key,data,target)};this.actions.set(key,action);return action;}
-  getPeers(){return Object.fromEntries([...this.peers].map(peerId=>[peerId,fakePeer()]));}
-  ping(peerId){
-    if(!this.peers.has(peerId))return Promise.reject(Error("Nostr VS relay peer unavailable"));
-    const nonce=packetId();return new Promise((resolve,reject)=>{const timer=setTimeout(()=>{this.pendingPings.delete(nonce);reject(Error("Nostr VS relay ping timeout"));},4000);this.pendingPings.set(nonce,{started:performance.now(),resolve:value=>{clearTimeout(timer);resolve(value);}});this._publish({...this._base("ping",peerId),nonce},false).catch(error=>{clearTimeout(timer);this.pendingPings.delete(nonce);reject(error);});});
-  }
-  leave(){
-    if(this.closed)return;
-    const goodbye=this._publish(this._base("bye"),false).catch(()=>{});
-    this.closed=true;clearInterval(this.helloTimer);clearInterval(this.heartbeatTimer);clearInterval(this.sweepTimer);clearTimeout(this.errorTimer);try{this.subscription?.close?.("room leave");}catch{}rooms.delete(this);for(const {resolve} of this.pendingPings.values())resolve(NaN);this.pendingPings.clear();this.peers.clear();this.peerKeys.clear();this.peerPublicKeys.clear();this.peerSeen.clear();goodbye.finally(()=>closePoolIfIdle());
-  }
+  getPeers(){return this.ready&&this.peerId?{[this.peerId]:peerSnapshot(this.pc,this.isHost)}:{};}
+  ping(peerId){if(!this.ready||peerId!==this.peerId)return Promise.reject(Error("Direct UDP peer unavailable"));const nonce=packetId();return new Promise((resolve,reject)=>{const timer=setTimeout(()=>{this.pendingPings.delete(nonce);reject(Error("Direct UDP ping timeout"));},3000);this.pendingPings.set(nonce,{started:performance.now(),resolve:value=>{clearTimeout(timer);resolve(value);},reject:error=>{clearTimeout(timer);reject(error);}});this._sendControl({a:"__ping",n:nonce}).catch(error=>{clearTimeout(timer);this.pendingPings.delete(nonce);reject(error);});});}
+  leave(){if(this.closed)return;const goodbye=this.peerId?this._publishSignal(this._base("bye",this.peerId)).catch(()=>{}):Promise.resolve();this.closed=true;clearInterval(this.helloTimer);clearInterval(this.heartbeatTimer);clearTimeout(this.errorTimer);clearTimeout(this.disconnectTimer);this.helloTimer=0;this.heartbeatTimer=0;this.errorTimer=0;this.disconnectTimer=0;try{this.subscription?.close?.("room leave");}catch{}try{this.pc?.close?.();}catch{}rooms.delete(this);for(const pending of this.pendingPings.values())pending.reject?.(Error("Direct UDP room closed"));this.pendingPings.clear();this.actions.clear();this.peerId="";this.pc=null;this.poseChannel=null;this.controlChannel=null;goodbye.finally(()=>closePoolIfIdle());}
 }
 
-export function joinRoom(config,roomId,callbacks={}){const id=String(roomId||"");if(!/^(?:net|tap)-/.test(id))throw Error("Nostr data relay requires an automatic network/proximity/gesture room");return new NostrRelayRoom(config,id,callbacks);}
+export function joinRoom(config,roomId,callbacks={}){const id=String(roomId||"");if(!/^(?:net|tap)-/.test(id))throw Error("Direct UDP matchmaking requires an automatic network/proximity/gesture room");return new DirectUdpRoom(config,id,callbacks);}

--- a/tests/staged_vs_smoke.mjs
+++ b/tests/staged_vs_smoke.mjs
@@ -29,6 +29,23 @@ const chromeFinder=new LanVsFinder({userAgent:chromeUa});
 assert.equal(chromeFinder.transportStrategies[0].name,"Nostr","non-Safari browsers must retain direct WebRTC-first matchmaking");
 assert.equal(chromeFinder.transportMode,"direct-first");
 
+const udpSource=readFileSync(new URL("../sim/nostr_data_relay.mjs",import.meta.url),"utf8");
+for(const marker of [
+  'transport:"DirectP2PUDP"',
+  'this.isHost=this.id<packet.id',
+  'createDataChannel("pose",{negotiated:true,id:0,ordered:false,maxRetransmits:0})',
+  'createDataChannel("control",{negotiated:true,id:1,ordered:true})',
+  'candidateProtocol(candidate)!=="udp"',
+  'iceRestart:true',
+  'POSE_BUFFER_LIMIT_BYTES',
+  'pose-drop-backpressure',
+  'pc.__a45HostAuthority=Boolean(isHost)',
+  'pc.__a45Transport="direct-p2p-udp"'
+])assert.ok(udpSource.includes(marker),`direct P2P UDP transport contract missing: ${marker}`);
+assert.ok(udpSource.includes('if(action==="pose")'),"pose must have a dedicated unreliable path");
+assert.ok(udpSource.includes('return this._sendControl({a:action,d:data});'),"origin/combat/control traffic must stay on the reliable channel");
+assert.equal(udpSource.includes('kind:"sealed"'),false,"relay must no longer carry gameplay payloads after pairing");
+
 let connected="";
 const finder=new LanVsFinder({stageMs:250,maxRoomsPerStage:3,transportStrategies:[{name:"Nostr",load:harness("Nostr",{fail:true})},{name:"NostrRelay",load:harness("NostrRelay",{connect:true})},{name:"Torrent",load:harness("Torrent")},{name:"MQTT",load:harness("MQTT")},{name:"Broker",load:harness("Broker")}],onPeer:(_peer,_room,transport)=>connected=transport});
 await finder.start(["net-exact","net-secondary","net-third","tap-current","tap-previous","net-extra"]);
@@ -43,7 +60,7 @@ for(const item of opened.filter(x=>!["Broker","NostrRelay"].includes(x.name))){
   assert.equal(item.config.rtcConfig?.iceTransportPolicy,"all",`${item.name} must explicitly keep direct ICE paths enabled`);
   assert.ok(Array.isArray(item.config.rtcConfig?.iceServers)&&item.config.rtcConfig.iceServers.length>=2,`${item.name} must explicitly carry STUN config`);
 }
-for(const item of opened.filter(x=>["Broker","NostrRelay"].includes(x.name)))assert.equal(item.config.rtcConfig,undefined,`${item.name} must bypass WebRTC ICE entirely`);
+for(const item of opened.filter(x=>["Broker","NostrRelay"].includes(x.name)))assert.equal(item.config.rtcConfig,undefined,`${item.name} owns its own signaling/direct-P2P setup and must not receive the Trystero RTC config`);
 finder.stop();
 
 const position={x:0,y:0,z:10},velocity={x:20,y:0,z:0},nextPosition={x:0,y:0,z:0},nextVelocity={x:0,y:0,z:0};
@@ -62,4 +79,4 @@ for(const marker of ["PROJECTILE_POOL_SIZE=36","TRACER_SPEED_MPS=210","PROJECTIL
 assert.equal(fireSource.includes("worldBridge?.registerVsHit?.(hit)"),false,"legacy instant hitscan damage path must not return");
 assert.ok(fireSource.includes("integrateProjectile(projectile.position,projectile.velocity,dt,projectile.nextPosition,projectile.nextVelocity);if(resolveProjectileHit(projectile,projectile.position,projectile.nextPosition,now))continue;"),"projectile time-of-flight must advance before segment collision resolution");assert.ok(fireSource.includes("registerVsHit?.(sceneHit)"),"VS damage must be emitted only from resolved projectile impact");
 
-console.log("Staged VS smoke passed: Safari relay-first matchmaking, staged networking, pooled physical tracers, 8x readable peer/1x hitbox, and safe-building launch integration retained.");
+console.log("Staged VS smoke passed: Safari signaling -> direct P2P UDP gameplay, host authority election, unreliable pose/reliable control channels, staged fallback networking, pooled physical tracers, 8x readable peer/1x hitbox, and safe-building launch integration retained.");


### PR DESCRIPTION
Reworks the Safari multiplayer path without adding infrastructure.

- Existing Nostr relays are used only for rendezvous + SDP/ICE signaling.
- Once peers are matched, gameplay moves to a direct RTCPeerConnection.
- Pose uses a negotiated unordered DataChannel with maxRetransmits: 0 (FPS-style unreliable UDP semantics).
- Origin, combat, state, respawn and ping use a separate reliable ordered DataChannel.
- ICE candidates are filtered to UDP only; direct failure still falls through to the existing relay transports.
- One player is deterministically elected host/authority.
- Pose backpressure drops stale updates rather than queueing them.
- ICE restart is attempted by the host on disconnect.
- Existing discovery, room selection, GPS/world-frame logic and infrastructure remain unchanged.

Includes mandatory staged VS assertions locking the direct-P2P-UDP contract.