### PR TITLE
Harden mobile double-tap zoom guard

### DIFF
--- a/sim/mobile_zoom_guard.mjs
+++ b/sim/mobile_zoom_guard.mjs
@@ -1,0 +1,22 @@
+const DOUBLE_TAP_MS=340;
+const UI_SELECTOR="button,input,select,textarea,a,label,dialog,[role=button],#soloTopbar,#soloLeft,#soloRight,#soloClearance,.solo-action,.phone-settings-dialog,#worldLookHud";
+
+let installed=false,lastTapAt=-Infinity;
+
+function viewport(){return document.getElementById("viewport");}
+function flightSurface(target){return target instanceof Element&&Boolean(target.closest("#viewport"))&&!target.closest(UI_SELECTOR);}
+function bump(){const v=viewport();if(!v)return;v.dataset.mobileDoubleTapBlocks=String((Number(v.dataset.mobileDoubleTapBlocks)||0)+1);v.dataset.mobileDoubleTapGuard="window-capture-v3";}
+
+export function installMobileZoomGuardCapture(){
+  if(installed)return;installed=true;
+  window.addEventListener("touchend",event=>{
+    if(!flightSurface(event.target)||event.changedTouches?.length!==1){lastTapAt=-Infinity;return;}
+    const now=Number.isFinite(Number(event.timeStamp))&&Number(event.timeStamp)>0?Number(event.timeStamp):performance.now();
+    if(now-lastTapAt<=DOUBLE_TAP_MS){event.preventDefault();bump();lastTapAt=-Infinity;return;}
+    lastTapAt=now;
+  },{capture:true,passive:false});
+  window.addEventListener("dblclick",event=>{if(!flightSurface(event.target))return;event.preventDefault();bump();},{capture:true,passive:false});
+  const v=viewport();if(v){v.dataset.mobileDoubleTapZoom="disabled-v2";v.dataset.mobileDoubleTapGuard="window-capture-v3";}
+}
+
+installMobileZoomGuardCapture();

--- a/sim/world_spawn_guard.mjs
+++ b/sim/world_spawn_guard.mjs
@@ -1,5 +1,6 @@
 import "./gameplay_polish_lite.mjs";
 import "./combat_visual_polish.mjs";
+import "./mobile_zoom_guard.mjs";
 import "./world_action_feedback.mjs";
 import "./foot_look_capture.mjs";
 import {buildingLaunchPointClear} from "./world_building_collision_physics.mjs";


### PR DESCRIPTION
Moves the double-tap prevention boundary to window capture so viewport/document input blockers cannot swallow the touchend pair. Keeps the existing viewport scale lock and world-action guard; functional smoke remains unchanged.