### PR TITLE
Use exported Box3D entry in combat module

### DIFF
--- a/sim/box3d_combat_world.mjs
+++ b/sim/box3d_combat_world.mjs
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import Box3DFactory from "box3d.js/dist/box3d.inline.mjs";
+import Box3DFactory from "box3d.js/inline";
 import {VS_FX_EVENT} from "./lan_vs.mjs";
 import {createWorldBuildingCollisionBodies,destroyWorldBuildingCollisionBodies} from "./world_building_collision_physics.mjs";
 


### PR DESCRIPTION
Fix the controller bundle failure by importing Box3D through the package's exported `box3d.js/inline` entry in the new combat module. No gameplay behavior changes; this only makes both simulator/controller dependency graphs resolvable by esbuild.