### PR TITLE
Detect VS v3 primary ownership from live state

### DIFF
--- a/sim/vs_multiplayer_guard.mjs
+++ b/sim/vs_multiplayer_guard.mjs
@@ -21,10 +21,9 @@ function patchLegacyPeerRenderer(){
   b.__vsV3PrimaryRenderGuard=true;
   const base=b.updateVsPeerRender.bind(b);
   b.updateVsPeerRender=(...args)=>{
-    if(b.vsPeerMesh?.userData?.vsLegacyPrimary){
-      const view=document.getElementById("viewport");if(view)view.dataset.vsPrimaryRenderOwner="multiplayer-v3";
-      return;
-    }
+    const view=document.getElementById("viewport"),v3OwnsPrimary=document.body.classList.contains("vs-multiplayer")&&Number(view?.dataset.vsPeerCount||0)>0&&Boolean(b.vsPeerMesh?.userData?.vsPlayerId);
+    if(v3OwnsPrimary){if(view)view.dataset.vsPrimaryRenderOwner="multiplayer-v3";return;}
+    if(view&&view.dataset.vsPrimaryRenderOwner==="multiplayer-v3")delete view.dataset.vsPrimaryRenderOwner;
     return base(...args);
   };
 }


### PR DESCRIPTION
Fix the ownership guard trigger: v3 assigns the shared primary mesh before the legacy flag branch can run, so detect ownership from the active `vs-multiplayer` state, peer count, and assigned primary player id. This keeps the legacy renderer from hiding the v3 primary peer while preserving legacy rendering outside v3 multiplayer.