### PR TITLE
Synchronize WALK aim before Box3D fire

### DIFF
--- a/sim/walk_aim_state_sync.mjs
+++ b/sim/walk_aim_state_sync.mjs
@@ -1,0 +1,19 @@
+let patched=null,tries=0;
+
+function viewport(){return document.getElementById("viewport");}
+function patch(){
+  const walk=globalThis.__arondightWalkMode;
+  if(!walk||typeof walk.setPose!=="function"){if(++tries<600)requestAnimationFrame(patch);return;}
+  if(walk===patched||walk.__walkAimStateSyncV1)return;patched=walk;
+  const base=walk.setPose.bind(walk);
+  walk.setPose=pose=>{
+    const result=base(pose);
+    const v=viewport(),yaw=Number(pose?.yaw),pitch=Number(pose?.pitch);
+    if(v){if(Number.isFinite(yaw))v.dataset.walkYaw=yaw.toFixed(4);if(Number.isFinite(pitch))v.dataset.walkPitch=pitch.toFixed(4);v.dataset.walkAimStateSync="setpose-immediate-v1";}
+    return result;
+  };
+  walk.__walkAimStateSyncV1=true;
+  const v=viewport();if(v)v.dataset.walkAimStateSync="setpose-immediate-v1";
+}
+
+patch();

--- a/sim/world_spawn_guard.mjs
+++ b/sim/world_spawn_guard.mjs
@@ -7,6 +7,7 @@ import "./walk_world_experience_hotfix.mjs";
 import "./world_visibility_continuity.mjs";
 import "./box3d_combat_world.mjs";
 import "./walk_weapon_system.mjs";
+import "./walk_aim_state_sync.mjs";
 import "./walk_ui_layout_hotfix.mjs";
 import {buildingLaunchPointClear} from "./world_building_collision_physics.mjs";
 


### PR DESCRIPTION
Fix the WALK combat race where programmatic/instant pose updates changed the canonical WALK state but Box3D weapon fire still read previous-frame DOM telemetry. setPose now synchronizes yaw/pitch telemetry immediately before fire routing; no recurring scan or extra steady-state work.