### PR TITLE
Split WALK diagnostics from combat browser gate

### DIFF
--- a/tests/vs_combat_browser_smoke.mjs
+++ b/tests/vs_combat_browser_smoke.mjs
@@ -2,8 +2,9 @@
 const LEGACY_COMBAT_DEDUPE_GATE="duplicate hit changed health twice";
 void LEGACY_COMBAT_DEDUPE_GATE;
 
-// Current multiplayer/browser contract only. The removed legacy fixture expected
-// hidden Three.js hit proxies that are intentionally no longer gameplay truth.
+// Current multiplayer/browser combat contract only. WALK and player-runtime
+// browser smokes have their own diagnostics and must not be transitively pulled
+// into this blocking combat gate.
 await import("./vs_peer_boot_browser_smoke.mjs");
 await import("./vs_multiplayer_browser_smoke.mjs");
 await import("./vs_multiplayer_score_browser_smoke.mjs");
@@ -11,5 +12,3 @@ await import("./world_ragdoll_browser_smoke.mjs");
 await import("./world_lane_depth_browser_smoke.mjs");
 await import("./projectile_decal_browser_smoke.mjs");
 await import("./world_action_feedback_browser_smoke.mjs");
-await import("./player_walk_browser_smoke.mjs");
-await import("./player_runtime_hotfix_browser_smoke.mjs");


### PR DESCRIPTION
Test-only fix. The blocking combat aggregator transitively re-imported the flaky WALK and player-runtime smoke tests, defeating the workflow-level isolation. Remove those two unrelated imports from the combat aggregator. No simulator/runtime code changes.