### PR TITLE
Revert later flight handoff

### DIFF
--- a/esp32/Arondight45_StateControl.hpp
+++ b/esp32/Arondight45_StateControl.hpp
@@ -122,7 +122,6 @@ public:
     void reset() {
         active_ = false;
         heading_source_valid_ = false;
-        manual_pitch_active_ = false;
         target_yaw_deg_ = 0.0f;
         hover_trim_ = kInitialHoverThrottle;
         reset_horizontal_state();
@@ -133,7 +132,6 @@ public:
     void leave_mode() {
         active_ = false;
         heading_source_valid_ = false;
-        manual_pitch_active_ = false;
         reset_horizontal_state();
         reset_command_targets();
         debug_ = {};
@@ -152,7 +150,6 @@ public:
         if (!active_ || heading_source_valid_ != absolute_heading_valid) {
             target_yaw_deg_ = measured_yaw_deg;
             heading_source_valid_ = absolute_heading_valid;
-            manual_pitch_active_ = false;
             reset_horizontal_state();
             reset_command_targets();
             active_ = true;
@@ -170,7 +167,6 @@ public:
         if (!inner_armed) {
             reset_horizontal_state();
             reset_command_targets();
-            manual_pitch_active_ = false;
             target_yaw_deg_ = measured_yaw_deg;
             heading_source_valid_ = absolute_heading_valid;
             debug_ = {intent.forward_mps, measured_forward,
@@ -181,33 +177,7 @@ public:
                       0.0f, 0.0f, 0.0f};
             return Command{0.0f, 0.0f, 0.0f, 0.0f, intent.arm};
         }
-
-        const bool manual_pitch_active = std::fabs(intent.body_pitch_deg) >= kManualPitchOverrideThresholdDeg;
-        const bool manual_pitch_released = manual_pitch_active_ && !manual_pitch_active;
-        manual_pitch_active_ = manual_pitch_active;
-
-        // GAME exposes two independent pilot intents on the forward axis: a
-        // velocity target (left stick) and physical body pitch (right stick).
-        // They must never fight each other. While body pitch is held, the pilot
-        // owns longitudinal attitude and the automatic forward velocity loop is
-        // transparent. On release, rebase the velocity target at the aircraft's
-        // actual speed and clear acceleration history so control hands back without
-        // an artificial reverse kick.
-        if (manual_pitch_released) {
-            commanded_forward_mps_ = measured_forward;
-            horizontal_target_initialized_ = true;
-            acceleration_estimator_valid_ = false;
-            acceleration_sample_dt_s_ = 0.0f;
-            previous_velocity_world_mps_ = nav.velocity_world_mps;
-            measured_acceleration_world_mps2_ = {};
-            horizontal_integral_forward_mps2_ = 0.0f;
-        }
-
         update_command_targets(intent, dt);
-        if (manual_pitch_active) {
-            commanded_forward_mps_ = measured_forward;
-            horizontal_integral_forward_mps2_ = 0.0f;
-        }
         update_acceleration_estimator(nav.velocity_world_mps, dt);
         const float measured_forward_accel = -c * measured_acceleration_world_mps2_.x - s * measured_acceleration_world_mps2_.y;
         const float measured_right_accel = -s * measured_acceleration_world_mps2_.x + c * measured_acceleration_world_mps2_.y;
@@ -257,15 +227,12 @@ public:
         const float neutral_damping_scale = pilot_horizontal_speed <= kHorizontalIntegralNeutralTargetMps
                                                 ? kHorizontalNeutralDampingScale
                                                 : 1.0f;
-        const float forward_feedback_unsat = kHorizontalVelocityGain * (commanded_forward_mps_ - measured_forward) + horizontal_integral_forward_mps2_ -
-                                             kHorizontalAccelerationDamping * neutral_damping_scale * measured_forward_accel;
+        const float forward_unsat = kHorizontalVelocityGain * (commanded_forward_mps_ - measured_forward) + horizontal_integral_forward_mps2_ -
+                                    kHorizontalAccelerationDamping * neutral_damping_scale * measured_forward_accel;
         const float right_unsat = kHorizontalVelocityGain * (commanded_right_mps_ - measured_right) + horizontal_integral_right_mps2_ -
                                   kHorizontalAccelerationDamping * neutral_damping_scale * measured_right_accel;
 
-        // A real body-pitch command is direct longitudinal attitude authority.
-        // Automatic forward acceleration/damping is therefore zero on that axis;
-        // otherwise the velocity loop would physically pitch against the pilot.
-        float forward_accel = manual_pitch_active ? 0.0f : forward_feedback_unsat;
+        float forward_accel = forward_unsat;
         float right_accel = right_unsat;
         // Keep the historical hardware authority available as a hard ceiling, but
         // do not drive the aircraft at that ceiling in normal GAME flight. The
@@ -289,11 +256,9 @@ public:
         // The horizontal I path is intentionally dormant in the stable envelope;
         // no stored propulsion may build up and kick the vehicle later.
         if (pilot_horizontal_speed > kHorizontalIntegralNeutralTargetMps) {
-            if (!manual_pitch_active) {
-                horizontal_integral_forward_mps2_ +=
-                    (kHorizontalIntegralGain * forward_error +
-                     kHorizontalAntiWindupGain * (forward_accel - forward_feedback_unsat)) * dt;
-            }
+            horizontal_integral_forward_mps2_ +=
+                (kHorizontalIntegralGain * forward_error +
+                 kHorizontalAntiWindupGain * (forward_accel - forward_unsat)) * dt;
             horizontal_integral_right_mps2_ +=
                 (kHorizontalIntegralGain * right_error +
                  kHorizontalAntiWindupGain * (right_accel - right_unsat)) * dt;
@@ -376,7 +341,6 @@ private:
     static_assert(kMaxAutoTranslationTiltDeg == 25.0f, "automatic GAME translation tilt envelope must stay at the validated 25 deg");
     static constexpr float kDegradedMaxTiltDeg = 12.0f;
     static constexpr float kDegradedBodyPitchScale = 0.35f;
-    static constexpr float kManualPitchOverrideThresholdDeg = 0.50f;
 
     static constexpr float kHorizontalVelocityGain = 0.80f;
     static constexpr float kHorizontalIntegralGain = 0.0f;
@@ -515,7 +479,6 @@ private:
 
     bool active_{};
     bool heading_source_valid_{};
-    bool manual_pitch_active_{};
     bool acceleration_estimator_valid_{};
     bool horizontal_target_initialized_{};
     bool vertical_accel_initialized_{};

--- a/tests/state_control_test.cpp
+++ b/tests/state_control_test.cpp
@@ -216,24 +216,6 @@ int main() {
     CHECK(cmd.pitch * fc::kInnerMaxAttitudeDeg < -24.9f);
     CHECK(cmd.throttle > 0.40f);
 
-    // Manual GAME pitch owns the longitudinal attitude axis. A vehicle that is
-    // already moving forward must not get an automatic counter-pitch from the
-    // velocity loop while the pilot is holding pitch. Releasing pitch rebases
-    // velocity control at the measured speed and starts only a gentle ramp-down.
-    controller.reset();
-    rc = base_rc(true);
-    rc.ch[fc::kStateBodyPitchChannel] = centered_raw(-1.0f);
-    nav = {{-6.0f, 0.0f, 0.0f}, 2.0f, true};
-    cmd = controller.run(rc, nav, 0.0f, true, 0.001f);
-    CHECK(controller.debug().measured_forward_mps > 5.99f);
-    CHECK(std::fabs(controller.debug().forward_accel_mps2) < 0.001f);
-    CHECK(cmd.pitch < -0.60f);
-    rc.ch[fc::kStateBodyPitchChannel] = centered_raw(0.0f);
-    cmd = controller.run(rc, nav, 0.0f, true, 0.001f);
-    CHECK(controller.debug().desired_forward_mps > 5.99f);
-    CHECK(controller.debug().forward_accel_mps2 < 0.0f);
-    CHECK(controller.debug().forward_accel_mps2 > -0.05f);
-
     controller.reset();
     rc = base_rc(true);
     nav.velocity_world_mps = {-1.0f, 0.0f, 0.0f};


### PR DESCRIPTION
Removes the just-restored PR #122 manual-pitch velocity handoff. User confirmed this is not the desired snappy controller version. Restores the exact pre-#122 controller/test state while older flight history is inspected separately.