### PR TITLE
Keep target fire alive under hit-stack churn

### DIFF
--- a/sim/combat_hit_stack_guard.mjs
+++ b/sim/combat_hit_stack_guard.mjs
@@ -1,0 +1,30 @@
+let installed=false,lastBridge=null,worldGuard=null,stableFrames=0;
+
+function bridge(){return globalThis.__arondightRealWorld||null;}
+function viewport(){return document.getElementById("viewport");}
+function telemetry(name,amount=1){const v=viewport();if(!v)return;v.dataset[name]=String((Number(v.dataset[name])||0)+amount);}
+function markStable(fn,base){
+  fn.__combatHitStackGuard=true;
+  fn.__gameplayPolishLiteWrapper=true;
+  fn.__gameplayPolishWrapper=true;
+  fn.__realityDamageTop=true;
+  fn.__worldLivelinessWrapper=true;
+  if(base?.__playerVehicleHitRouterV2)fn.__playerVehicleHitRouterV2=true;
+  if(base?.__proceduralPopulationProvider)fn.__proceduralPopulationProvider=true;
+  return fn;
+}
+function installWorldGuard(){
+  const b=bridge();if(!b||typeof b.registerWorldPopulationHit!=="function")return false;
+  if(b!==lastBridge){lastBridge=b;worldGuard=null;stableFrames=0;}
+  const current=b.registerWorldPopulationHit;
+  if(current===worldGuard){stableFrames++;const v=viewport();if(v){v.dataset.combatHitStackGuard="stable-v1";v.dataset.combatHitStackStableFrames=String(stableFrames);}return true;}
+  const base=current.bind(b),guard=markStable(function(hit){
+    try{return Boolean(base(hit));}
+    catch(error){telemetry("combatHitStackErrors");const v=viewport();if(v)v.dataset.combatHitStackLastError=String(error?.message||error||"target-hit-error").slice(0,160);return false;}
+  },current);
+  worldGuard=guard;b.registerWorldPopulationHit=guard;stableFrames=0;telemetry("combatHitStackWraps");const v=viewport();if(v)v.dataset.combatHitStackGuard="installed-v1";return true;
+}
+function loop(){installWorldGuard();requestAnimationFrame(loop);}
+
+export function installCombatHitStackGuard(){if(installed)return;installed=true;requestAnimationFrame(loop);}
+installCombatHitStackGuard();

--- a/sim/combat_hit_stack_guard.mjs
+++ b/sim/combat_hit_stack_guard.mjs
@@ -1,30 +1,42 @@
-let installed=false,lastBridge=null,worldGuard=null,stableFrames=0;
+let installed=false,lastBridge=null,worldGuard=null,vsGuard=null,stableFrames=0;
 
 function bridge(){return globalThis.__arondightRealWorld||null;}
 function viewport(){return document.getElementById("viewport");}
 function telemetry(name,amount=1){const v=viewport();if(!v)return;v.dataset[name]=String((Number(v.dataset[name])||0)+amount);}
-function markStable(fn,base){
+function copyMarker(fn,base,name){if(base?.[name])fn[name]=true;}
+function markWorldStable(fn,base){
   fn.__combatHitStackGuard=true;
   fn.__gameplayPolishLiteWrapper=true;
   fn.__gameplayPolishWrapper=true;
   fn.__realityDamageTop=true;
   fn.__worldLivelinessWrapper=true;
-  if(base?.__playerVehicleHitRouterV2)fn.__playerVehicleHitRouterV2=true;
-  if(base?.__proceduralPopulationProvider)fn.__proceduralPopulationProvider=true;
+  for(const name of["__playerVehicleHitRouterV2","__proceduralPopulationProvider"])copyMarker(fn,base,name);
   return fn;
 }
-function installWorldGuard(){
-  const b=bridge();if(!b||typeof b.registerWorldPopulationHit!=="function")return false;
-  if(b!==lastBridge){lastBridge=b;worldGuard=null;stableFrames=0;}
-  const current=b.registerWorldPopulationHit;
-  if(current===worldGuard){stableFrames++;const v=viewport();if(v){v.dataset.combatHitStackGuard="stable-v1";v.dataset.combatHitStackStableFrames=String(stableFrames);}return true;}
-  const base=current.bind(b),guard=markStable(function(hit){
-    try{return Boolean(base(hit));}
-    catch(error){telemetry("combatHitStackErrors");const v=viewport();if(v)v.dataset.combatHitStackLastError=String(error?.message||error||"target-hit-error").slice(0,160);return false;}
-  },current);
-  worldGuard=guard;b.registerWorldPopulationHit=guard;stableFrames=0;telemetry("combatHitStackWraps");const v=viewport();if(v)v.dataset.combatHitStackGuard="installed-v1";return true;
+function markVsStable(fn,base){
+  fn.__combatHitStackGuard=true;
+  for(const name of["__worldActionFeedbackWrapper","__vsCombatHitRouter","__playerVehicleHitRouterV2"])copyMarker(fn,base,name);
+  return fn;
 }
-function loop(){installWorldGuard();requestAnimationFrame(loop);}
+function guarded(base,kind,mark,current){return mark(function(hit){
+  try{return Boolean(base(hit));}
+  catch(error){telemetry("combatHitStackErrors");const v=viewport();if(v){v.dataset.combatHitStackLastError=String(error?.message||error||`${kind}-target-hit-error`).slice(0,160);v.dataset.combatHitStackLastKind=kind;}return false;}
+},current);}
+function installGuards(){
+  const b=bridge();if(!b)return false;
+  if(b!==lastBridge){lastBridge=b;worldGuard=null;vsGuard=null;stableFrames=0;}
+  let changed=false;
+  if(typeof b.registerWorldPopulationHit==="function"){
+    const current=b.registerWorldPopulationHit;
+    if(current!==worldGuard){worldGuard=guarded(current.bind(b),"world",markWorldStable,current);b.registerWorldPopulationHit=worldGuard;telemetry("combatHitStackWraps");changed=true;}
+  }
+  if(typeof b.registerVsHit==="function"){
+    const current=b.registerVsHit;
+    if(current!==vsGuard){vsGuard=guarded(current.bind(b),"vs",markVsStable,current);b.registerVsHit=vsGuard;telemetry("combatVsHitGuardWraps");changed=true;}
+  }
+  stableFrames=changed?0:stableFrames+1;const v=viewport();if(v){v.dataset.combatHitStackGuard=changed?"installed-v1":"stable-v1";v.dataset.combatHitStackStableFrames=String(stableFrames);}return true;
+}
+function loop(){installGuards();requestAnimationFrame(loop);}
 
 export function installCombatHitStackGuard(){if(installed)return;installed=true;requestAnimationFrame(loop);}
 installCombatHitStackGuard();

--- a/sim/world_spawn_guard.mjs
+++ b/sim/world_spawn_guard.mjs
@@ -5,6 +5,7 @@ import "./world_action_feedback.mjs";
 import "./foot_look_capture.mjs";
 import "./walk_world_experience_hotfix.mjs";
 import "./walk_ui_layout_hotfix.mjs";
+import "./combat_hit_stack_guard.mjs";
 import {buildingLaunchPointClear} from "./world_building_collision_physics.mjs";
 
 let installed=false;

--- a/tests/combat_center_fire_browser_smoke.mjs
+++ b/tests/combat_center_fire_browser_smoke.mjs
@@ -8,6 +8,7 @@ if(!executablePath)throw new Error("CHROME_BIN must point to Chrome/Chromium");
 
 const browser=await puppeteer.launch({headless:true,executablePath,args:["--no-sandbox","--disable-dev-shm-usage","--enable-webgl","--ignore-gpu-blocklist","--use-gl=angle","--use-angle=swiftshader"]});
 const page=await browser.newPage();
+const sleep=ms=>new Promise(resolve=>setTimeout(resolve,ms));
 try{
   await page.setViewport({width:844,height:390,deviceScaleFactor:1});
   await page.goto(url.href,{waitUntil:"load",timeout:30000});
@@ -28,6 +29,16 @@ try{
   if(fired.mode!=="touch-1to1"||Math.abs(fired.x-fired.expectedX)>1||Math.abs(fired.y-fired.expectedY)>1||fired.recoil<=before.recoil)throw new Error(`touch hitscan not 1:1/recoiling: ${JSON.stringify(fired)}`);
   await page.evaluate(()=>document.querySelector("#viewport").dispatchEvent(new PointerEvent("pointerup",{bubbles:true,cancelable:true,pointerId:77,pointerType:"touch",button:0})));
 
+  await page.waitForFunction(()=>Number(document.querySelector("#viewport")?.dataset.combatHitStackStableFrames||0)>=8,{timeout:4000});
+  const stack=await page.evaluate(async()=>{const wait=ms=>new Promise(r=>setTimeout(r,ms)),b=globalThis.__arondightRealWorld,v=document.querySelector("#viewport"),world=b?.registerWorldPopulationHit,vs=b?.registerVsHit,wraps=Number(v?.dataset.combatHitStackWraps||0);await wait(350);return{guard:v?.dataset.combatHitStackGuard||"",worldStable:world===b?.registerWorldPopulationHit,vsStable:vs===b?.registerVsHit,wrapsBefore:wraps,wrapsAfter:Number(v?.dataset.combatHitStackWraps||0)};});
+  if(stack.guard!=="stable-v1"||!stack.worldStable||!stack.vsStable||stack.wrapsAfter!==stack.wrapsBefore)throw new Error(`target hit stack still grows over time: ${JSON.stringify(stack)}`);
+
+  const stressBefore=await page.evaluate(async()=>{const wait=ms=>new Promise(r=>setTimeout(r,ms)),b=globalThis.__arondightRealWorld,v=document.querySelector("#viewport"),scene=b?.threeScene,camera=b?.threeCamera;let source=null;scene?.traverse?.(node=>{if(!source&&node?.isMesh&&node.geometry&&!node.userData?.flightFireDecal&&!node.userData?.flightFireTracer)source=node;});if(!source||!camera)throw Error("target fire stress needs one scene mesh and camera");const target=source.clone(false);target.name="TARGET_FIRE_STRESS";target.userData={...target.userData,worldPopulationKind:"person",worldPopulationId:"target-fire-stress",flightFireIgnore:false,arondightAirframe:false};target.raycast=source.raycast;const dir=camera.position.clone();camera.getWorldDirection(dir);target.position.copy(camera.position).addScaledVector(dir,5);target.scale.setScalar(4);target.updateMatrixWorld(true);scene.add(target);b.registerWorldPopulationHit=()=>{throw Error("synthetic target-hit failure");};await wait(120);const r=v.getBoundingClientRect(),clientX=r.left+r.width/2,clientY=r.top+r.height/2,before={shots:Number(v.dataset.fireShots||0),rays:Number(v.dataset.fireRaycastShots||0),errors:Number(v.dataset.combatHitStackErrors||0)};v.dispatchEvent(new PointerEvent("pointerdown",{bubbles:true,cancelable:true,pointerId:88,pointerType:"touch",clientX,clientY,button:0}));return before;});
+  await sleep(1350);
+  const stressAfter=await page.$eval("#viewport",v=>({shots:Number(v.dataset.fireShots||0),rays:Number(v.dataset.fireRaycastShots||0),errors:Number(v.dataset.combatHitStackErrors||0),source:v.dataset.fireInputSource,guard:v.dataset.combatHitStackGuard}));
+  await page.evaluate(()=>document.querySelector("#viewport").dispatchEvent(new PointerEvent("pointerup",{bubbles:true,cancelable:true,pointerId:88,pointerType:"touch",button:0})));
+  if(stressAfter.shots-stressBefore.shots<10||stressAfter.rays-stressBefore.rays<10||stressAfter.errors<=stressBefore.errors||stressAfter.guard!=="stable-v1")throw new Error(`target handler stopped sustained fire: ${JSON.stringify({stressBefore,stressAfter})}`);
+
   const feedback=await page.evaluate(()=>{
     dispatchEvent(new CustomEvent("arondight:combat-damage",{detail:{damage:25,hp:75}}));
     dispatchEvent(new CustomEvent("arondight:combat-hit-confirm",{detail:{hp:75}}));
@@ -35,5 +46,5 @@ try{
   });
   if(!feedback.damage||!feedback.hit)throw new Error(`combat feedback missing: ${JSON.stringify(feedback)}`);
 
-  console.log("Hitscan browser smoke passed: zero projectile pool, immediate raycast shot, 1:1 touch aim, recoil and visible combat feedback.");
+  console.log("Hitscan browser smoke passed: zero projectile pool, immediate raycast shot, 1:1 touch aim, stable target-hit wrapper stack, sustained fire survives target-handler failures, recoil and combat feedback.");
 }finally{await browser.close();}


### PR DESCRIPTION
Fix sustained shooting stopping after repeated target hits. Existing WORLD target wrappers could alternate around each other over time, growing the call chain only on target hits. Add one stable top-level hit guard that preserves the established damage/population chain, marks the gameplay/reality wrappers as already present, catches target-handler exceptions, and re-stabilizes if a later legitimate wrapper is installed. Extend the existing combat browser smoke (no extra suite) to assert the hit handler identity stops changing and sustained hitscan keeps firing even when a target handler throws.