### PR TITLE
Keep drag-fire stress ray on target

### DIFF
--- a/tests/combat_center_fire_browser_smoke.mjs
+++ b/tests/combat_center_fire_browser_smoke.mjs
@@ -32,7 +32,7 @@ try{
     scene.traverse(node=>{if(node?.isMesh)node.userData.flightFireIgnore=true;});
     const target=source.clone(false),dir=camera.position.clone();camera.getWorldDirection(dir);
     target.name="TARGET_FIRE_STRESS";target.userData={worldPopulationKind:"person",worldPopulationId:"target-fire-stress",flightFireIgnore:false};
-    target.position.copy(camera.position).addScaledVector(dir,3);target.quaternion.copy(camera.quaternion);target.scale.setScalar(8);target.visible=true;target.frustumCulled=false;scene.add(target);scene.updateMatrixWorld(true);target.updateMatrixWorld(true);
+    target.position.copy(camera.position).addScaledVector(dir,3);target.quaternion.copy(camera.quaternion);target.scale.setScalar(120);target.visible=true;target.frustumCulled=false;scene.add(target);scene.updateMatrixWorld(true);target.updateMatrixWorld(true);
     const base=b.registerWorldPopulationHit;let hits=0;
     b.registerWorldPopulationHit=hit=>{if(hit?.object===target){hits++;v.dataset.testTargetHitCalls=String(hits);return true;}return Boolean(base(hit));};
     await wait(250);


### PR DESCRIPTION
Test-only. The previous run proved 19/19 shots and raycasts with stable handler identity and 2/2 assignments; only the synthetic target left the ray during drag. Enlarge the isolated target so the regression test measures sustained firing while remaining over target. Runtime unchanged.