### PR TITLE
Keep WORLD spawn relocation physics-owned

### DIFF
--- a/sim/world_spawn_guard.mjs
+++ b/sim/world_spawn_guard.mjs
@@ -19,14 +19,19 @@ let installed=false;
 
 export function installWorldSpawnGuard(){
   if(installed)return true;const bridge=globalThis.__arondightRealWorld;if(!bridge||typeof bridge.attachBuildingCollisionSink!=="function")return false;installed=true;
-  const baseAttach=bridge.attachBuildingCollisionSink.bind(bridge);let lastPrismCount=0,resetQueued=false;
+  const baseAttach=bridge.attachBuildingCollisionSink.bind(bridge);let lastPrismCount=0;
   bridge.attachBuildingCollisionSink=sink=>baseAttach(snapshot=>{
-    const prismCount=Math.max(0,Number(snapshot?.prismCount)||0),firstLoaded=lastPrismCount===0&&prismCount>0,scene=bridge.threeScene,airframe=scene?bridge.airframeFor?.(scene):null,p=airframe?.position,nearGround=Number.isFinite(p?.z)&&p.z<.35,unsafe=firstLoaded&&nearGround&&!buildingLaunchPointClear(snapshot,[Number(p?.x)||0,Number(p?.y)||0],{clearanceM:.9});
-    lastPrismCount=prismCount;sink(snapshot);
-    const viewport=document.getElementById("viewport");if(viewport){viewport.dataset.worldSpawnGuard=unsafe?"relocate":firstLoaded?"clear":prismCount?"tracking":"waiting";viewport.dataset.worldSpawnGuardPrisms=String(prismCount);}
-    if(!unsafe||resetQueued)return;resetQueued=true;queueMicrotask(()=>{
-      resetQueued=false;const button=document.getElementById("soloReset");if(!button)return;if(viewport){viewport.dataset.worldSpawnGuardResets=String((Number(viewport.dataset.worldSpawnGuardResets)||0)+1);viewport.dataset.worldSpawnGuard="resetting-to-clear-launch";}button.click();
-    });
+    const prismCount=Math.max(0,Number(snapshot?.prismCount)||0),firstLoaded=lastPrismCount===0&&prismCount>0,scene=bridge.threeScene,airframe=scene?bridge.airframeFor?.(scene):null,p=airframe?.position,nearGround=Number.isFinite(p?.z)&&p.z<.35,unsafeBefore=firstLoaded&&nearGround&&!buildingLaunchPointClear(snapshot,[Number(p?.x)||0,Number(p?.y)||0],{clearanceM:.9});
+    lastPrismCount=prismCount;
+    // PhysicsModel.setWorldBuildingCollisions() already resolves a collision-free
+    // launch point before it creates the static building bodies and then snaps the
+    // rigid body to the actual Box3D support surface. A UI RESET here used to
+    // destroy that freshly rebuilt Box3D world and put the aircraft back at the
+    // original GPS origin, which could leave the visual/physics spawn buried and
+    // NAV invalid. Keep exactly one owner: the collision sink.
+    const result=sink(snapshot);
+    const viewport=document.getElementById("viewport");if(viewport){viewport.dataset.worldSpawnGuard=unsafeBefore?"physics-relocate":firstLoaded?"clear":prismCount?"tracking":"waiting";viewport.dataset.worldSpawnGuardPrisms=String(prismCount);viewport.dataset.worldSpawnGuardPolicy="physics-sink-single-owner-v2";}
+    return result;
   });
   return true;
 }

--- a/tests/staged_vs_smoke.mjs
+++ b/tests/staged_vs_smoke.mjs
@@ -93,8 +93,10 @@ assert.equal(buildingSource.includes("skipWholeBuilding"),false,"WORLD launch mu
 for(const marker of ["pointHasLaunchClearance(candidate,active,clearance)","guaranteedRadius","No collision-free WORLD launch point could be proven"])
   assert.ok(buildingSource.includes(marker),`WORLD launch proof contract missing: ${marker}`);
 const spawnGuardSource=readFileSync(new URL("../sim/world_spawn_guard.mjs",import.meta.url),"utf8");
-for(const marker of ["firstLoaded","buildingLaunchPointClear","queueMicrotask","soloReset","worldSpawnGuardResets","combat_visual_polish.mjs"])
+for(const marker of ["firstLoaded","buildingLaunchPointClear","physics-sink-single-owner-v2","combat_visual_polish.mjs"])
   assert.ok(spawnGuardSource.includes(marker),`delayed WORLD-collider/combat polish guard missing: ${marker}`);
+for(const forbidden of ["queueMicrotask","soloReset","worldSpawnGuardResets"])
+  assert.equal(spawnGuardSource.includes(forbidden),false,`WORLD spawn guard must not reset after the physics sink relocated the aircraft: ${forbidden}`);
 
 await import("./multiplayer_mesh_smoke.mjs");
-console.log("Staged VS smoke passed: direct P2P UDP mesh, deterministic Box3D hitscan fire, unique players, replicated fire/explosions, authority migration, hardened WORLD spawn and road traffic retained.");
+console.log("Staged VS smoke passed: direct P2P UDP mesh, deterministic Box3D hitscan fire, unique players, replicated fire/explosions, authority migration, physics-owned WORLD spawn and road traffic retained.");


### PR DESCRIPTION
Fixes the GPS/WORLD startup regression where the delayed building-collision guard reset the simulator after PhysicsModel had already relocated the aircraft to a collision-free launch point. That reset destroyed the freshly rebuilt Box3D world and returned the drone to the unsafe origin. Remove the second reset and keep relocation/collider construction under the existing PhysicsModel sink as the single owner. Update the source contract accordingly.