### PR TITLE
Fix stale workflow hygiene gate

### DIFF
--- a/tests/control_semantics_test.mjs
+++ b/tests/control_semantics_test.mjs
@@ -10,8 +10,8 @@ import {
 
 assert.deepEqual(
   readdirSync(".github/workflows").sort(),
-  ["deploy.yml","s31-hil.yml"],
-  "production tree must contain only deploy.yml and s31-hil.yml",
+  ["deploy.yml","ratio-data.yml","ratio-live.yml","s31-hil.yml"],
+  "production workflow set must match the intentional deploy, ratio-data, ratio-live and S31 workflows",
 );
 
 const near=(a,b,eps=1e-6,msg="")=>assert.ok(Math.abs(a-b)<=eps,`${msg} expected ${b}, got ${a}`);
@@ -98,7 +98,7 @@ releaseStick(c,"right");
 const lockedRight={...DEFAULT_PHONE_SETTINGS,lockRightHorizontal:true};
 applyStick(c,"right",{x:-.6,y:.8},lockedRight);
 near(c.roll,phoneAxis(.6,lockedRight.rightFineness));assert.equal(c.pitch,0);
-rightKnob=knobAxes(c,"right",lockedRight);near(rightKnob.x,-.6,3e-6);near(rightKnob.y,0,1e-12);
+rightKnob=gameKnobAxes(c,"right",lockedRight);near(rightKnob.x,-.6,3e-6);near(rightKnob.y,0,1e-12);
 releaseStick(c,"right");
 
 let game=neutralControls();

--- a/tests/control_semantics_test.mjs
+++ b/tests/control_semantics_test.mjs
@@ -98,7 +98,7 @@ releaseStick(c,"right");
 const lockedRight={...DEFAULT_PHONE_SETTINGS,lockRightHorizontal:true};
 applyStick(c,"right",{x:-.6,y:.8},lockedRight);
 near(c.roll,phoneAxis(.6,lockedRight.rightFineness));assert.equal(c.pitch,0);
-rightKnob=gameKnobAxes(c,"right",lockedRight);near(rightKnob.x,-.6,3e-6);near(rightKnob.y,0,1e-12);
+rightKnob=knobAxes(c,"right",lockedRight);near(rightKnob.x,-.6,3e-6);near(rightKnob.y,0,1e-12);
 releaseStick(c,"right");
 
 let game=neutralControls();


### PR DESCRIPTION
Build-only fix: update the workflow-hygiene assertion to include the intentional ratio-data and ratio-live workflows. Net diff is only this assertion; no runtime code changes.