### PR TITLE
Fix sticky WALK building collisions and deploy gates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           node tests/world_pedestrian_navigation_test.mjs
           node tests/world_defaults_contract_test.mjs
           node tests/player_multiplayer_replication_contract_test.mjs
+          node tests/walk_collision_resolution_test.mjs
           node --check sim/player_walk_mode_v4.mjs
           node --check sim/player_car_mode.mjs
           node --check sim/gameplay_final_runtime_v2.mjs
@@ -60,6 +61,7 @@ jobs:
           node --check sim/wanted_police_drones.mjs
           node --check sim/world_procedural_population.mjs
           node --check sim/camera_collision_guard.mjs
+          node --check sim/walk_collision_resolution.mjs
           test ! -e sim/camera_box3d_spring.mjs
           ! grep -R -E 'CameraBox3dSpring|box3d-dynamic-spring' sim tests --exclude-dir=node_modules
           grep -q 'playerCameraPhysicsBody="none"' sim/camera_collision_guard.mjs
@@ -142,8 +144,8 @@ jobs:
           CHROME_BIN="$CHROME_BIN" node tests/player_car_touch_browser_smoke.mjs http://127.0.0.1:4174/drone_simulator.html
           CHROME_BIN="$CHROME_BIN" node tests/world_imagery_default_browser_smoke.mjs http://127.0.0.1:4174/drone_simulator.html
 
-      - name: FPS regression smoke
-        timeout-minutes: 4
+      - name: FPS + target drag regression smoke
+        timeout-minutes: 6
         run: |
           set -euxo pipefail
           CHROME_BIN="$(command -v google-chrome || command -v chromium || command -v chromium-browser || true)"
@@ -152,7 +154,8 @@ jobs:
           HTTP_PID=$!
           trap 'kill "$HTTP_PID" 2>/dev/null || true; pkill -9 -f "chrome|chromium" 2>/dev/null || true; rm -f node_modules' EXIT
           sleep 1
-          CHROME_BIN="$CHROME_BIN" node tests/fps_first_person_browser_smoke.mjs http://127.0.0.1:4174/drone_simulator.html
+          CHROME_BIN="$CHROME_BIN" node tests/fps_input_browser_smoke.mjs http://127.0.0.1:4174/drone_simulator.html
+          CHROME_BIN="$CHROME_BIN" node tests/combat_center_fire_browser_smoke.mjs http://127.0.0.1:4174/drone_simulator.html
           CHROME_BIN="$CHROME_BIN" node tests/player_multiplayer_modes_browser_smoke.mjs http://127.0.0.1:4174/drone_simulator.html
 
       - uses: actions/configure-pages@v5

--- a/sim/walk_collision_resolution.mjs
+++ b/sim/walk_collision_resolution.mjs
@@ -1,0 +1,67 @@
+const WALK_RADIUS_M=.28;
+const MAX_SUBSTEP_M=.14;
+const EDGE_SEARCH_M=WALK_RADIUS_M*2.5;
+const EPS=1e-7;
+
+const finite=value=>Number.isFinite(Number(value));
+const point=value=>({x:finite(value?.x)?Number(value.x):0,y:finite(value?.y)?Number(value.y):0});
+const distanceSq=(a,b)=>{const dx=a.x-b.x,dy=a.y-b.y;return dx*dx+dy*dy;};
+
+function closestPointOnSegment(p,a,b){
+  const dx=b[0]-a[0],dy=b[1]-a[1],l2=dx*dx+dy*dy;
+  if(l2<=EPS)return{x:a[0],y:a[1],tangent:null};
+  const t=Math.max(0,Math.min(1,((p.x-a[0])*dx+(p.y-a[1])*dy)/l2)),len=Math.sqrt(l2);
+  return{x:a[0]+dx*t,y:a[1]+dy*t,tangent:{x:dx/len,y:dy/len}};
+}
+
+function nearbyBuildingEdges(p,prisms,maxDistance=EDGE_SEARCH_M){
+  const maxD2=maxDistance*maxDistance,edges=[];
+  for(const prism of prisms||[]){
+    const points=Array.isArray(prism?.points)?prism.points:null;if(!points||points.length<2)continue;
+    for(let i=0;i<points.length;i++){
+      const a=points[i],b=points[(i+1)%points.length];if(!Array.isArray(a)||!Array.isArray(b))continue;
+      const q=closestPointOnSegment(p,a,b);if(!q.tangent)continue;const d2=distanceSq(p,q);if(d2<=maxD2)edges.push({distanceSq:d2,tangent:q.tangent});
+    }
+  }
+  edges.sort((a,b)=>a.distanceSq-b.distanceSq);return edges.slice(0,6);
+}
+
+function safeOccupy(canOccupy,x,y){try{return Boolean(canOccupy(x,y));}catch{return false;}}
+
+export function resolveWalkCollisionMove(fromValue,toValue,{canOccupy,baseResolve,prisms=[]}={}){
+  const from=point(fromValue),to=point(toValue),fallback=()=>typeof baseResolve==="function"?baseResolve(fromValue,toValue):from;
+  if(typeof canOccupy!=="function")return fallback();
+  if(!safeOccupy(canOccupy,from.x,from.y))return fallback();
+  if(safeOccupy(canOccupy,to.x,to.y))return to;
+  const dx=to.x-from.x,dy=to.y-from.y,distance=Math.hypot(dx,dy);if(distance<=EPS)return from;
+  const steps=Math.max(1,Math.ceil(distance/MAX_SUBSTEP_M)),stepX=dx/steps,stepY=dy/steps;
+  let current={...from},moved=false,slid=false;
+  for(let i=0;i<steps;i++){
+    const desired={x:current.x+stepX,y:current.y+stepY};
+    if(safeOccupy(canOccupy,desired.x,desired.y)){current=desired;moved=true;continue;}
+    let best=null,bestMagnitude=0;
+    for(const edge of nearbyBuildingEdges(desired,prisms)){
+      const t=edge.tangent,projection=stepX*t.x+stepY*t.y;if(Math.abs(projection)<=EPS)continue;
+      const candidate={x:current.x+t.x*projection,y:current.y+t.y*projection};if(!safeOccupy(canOccupy,candidate.x,candidate.y))continue;
+      const magnitude=Math.abs(projection);if(magnitude>bestMagnitude+EPS){best=candidate;bestMagnitude=magnitude;}
+    }
+    if(best){current=best;moved=true;slid=true;continue;}
+    let shortened=null;
+    for(const scale of[.5,.25]){const candidate={x:current.x+stepX*scale,y:current.y+stepY*scale};if(safeOccupy(canOccupy,candidate.x,candidate.y)){shortened=candidate;break;}}
+    if(shortened){current=shortened;moved=true;continue;}
+    break;
+  }
+  if(!moved)return fallback();
+  return{x:current.x,y:current.y,__walkCollisionSlide:slid};
+}
+
+function viewport(){return typeof document!=="undefined"?document.getElementById("viewport"):null;}
+function bridge(){return globalThis.__arondightRealWorld||null;}
+let installed=false,installFrame=0;
+export function installWalkCollisionResolution(){
+  if(installed)return true;const runtime=globalThis.__arondightPlayerVehicleRuntime;if(!runtime||typeof runtime.resolveWalkMove!=="function"||typeof runtime.canOccupyWalkPoint!=="function")return false;
+  const base=runtime.resolveWalkMove.bind(runtime),canOccupy=runtime.canOccupyWalkPoint.bind(runtime),resolved=(from,to)=>resolveWalkCollisionMove(from,to,{canOccupy,baseResolve:base,prisms:bridge()?.buildingCollisionSnapshot?.prisms||[]});
+  resolved.__walkCollisionResolutionV1=true;runtime.resolveWalkMove=resolved;installed=true;const view=viewport();if(view){view.dataset.walkCollisionResolution="substep+building-edge-tangent-v1";view.dataset.walkCollisionOwner="walk-collision-resolution-v1";}return true;
+}
+function installWhenReady(){if(installWalkCollisionResolution())return;installFrame=requestAnimationFrame(installWhenReady);}
+if(typeof requestAnimationFrame==="function")installWhenReady();

--- a/sim/world_spawn_guard.mjs
+++ b/sim/world_spawn_guard.mjs
@@ -12,6 +12,7 @@ import "./camera_collision_guard.mjs";
 import "./world_network_physics_sync.mjs";
 import "./world_explosion_acoustics.mjs";
 import "./walk_ui_layout_hotfix.mjs";
+import "./walk_collision_resolution.mjs";
 import "./combat_hit_stack_guard.mjs";
 import {buildingLaunchPointClear} from "./world_building_collision_physics.mjs";
 

--- a/tests/fps_input_browser_smoke.mjs
+++ b/tests/fps_input_browser_smoke.mjs
@@ -1,0 +1,30 @@
+import puppeteer from "puppeteer-core";
+
+const input=process.argv[2]||"http://127.0.0.1:4174/drone_simulator.html",url=new URL(input,"http://127.0.0.1:4174"),executablePath=process.env.CHROME_BIN;
+if(!executablePath)throw new Error("CHROME_BIN must point to Chrome/Chromium");if(process.env.GITHUB_SHA)url.searchParams.set("ci",process.env.GITHUB_SHA);
+const browser=await puppeteer.launch({headless:true,executablePath,args:["--no-sandbox","--disable-dev-shm-usage","--enable-webgl","--ignore-gpu-blocklist","--use-gl=angle","--use-angle=swiftshader"]}),page=await browser.newPage();
+const pause=ms=>page.evaluate(delay=>new Promise(resolve=>setTimeout(resolve,delay)),ms);
+try{
+  await page.setViewport({width:960,height:540,deviceScaleFactor:1,hasTouch:true});await page.goto(url.href,{waitUntil:"load",timeout:30000});
+  await page.waitForFunction(()=>document.querySelector("#status")?.textContent?.includes("SIM ready")&&globalThis.__arondightWalkMode&&globalThis.__arondightPlayerVehicleRuntime,{timeout:30000});
+  await page.evaluate(()=>{globalThis.__arondightPlayerDamageModel?.reset?.();globalThis.__arondightWalkMode.setMode("foot",{persist:false});});
+  await page.waitForFunction(()=>{const v=document.querySelector("#viewport");return v?.dataset.playerMode==="foot"&&document.querySelector("#footMove")&&document.querySelector("#footLookZone")&&v.dataset.walkCollisionResolution==="substep+building-edge-tangent-v1";},{timeout:5000});
+
+  const movePoint=await page.$eval("#footMove",el=>{const r=el.getBoundingClientRect(),id=773,center={x:r.left+r.width/2,y:r.top+r.height/2},edge={x:r.right-2,y:r.top+r.height/2};el.dispatchEvent(new PointerEvent("pointerdown",{bubbles:true,cancelable:true,pointerId:id,pointerType:"touch",button:0,buttons:1,clientX:center.x,clientY:center.y}));el.dispatchEvent(new PointerEvent("pointermove",{bubbles:true,cancelable:true,pointerId:id,pointerType:"touch",button:0,buttons:1,clientX:edge.x,clientY:edge.y}));return edge;});await pause(80);
+  const initial=await page.$eval("#viewport",v=>({move:v.dataset.walkMove,owner:v.dataset.walkMoveStickOwner,magnitude:Number(v.dataset.walkMoveStickMagnitude||0)}));
+  if(initial.owner!=="773"||initial.magnitude<.94||String(initial.move||"").startsWith("0.000,0.000"))throw new Error(`left move pointer failed: ${JSON.stringify(initial)}`);
+
+  await page.$eval("#footLook",el=>el.dispatchEvent(new PointerEvent("lostpointercapture",{bubbles:true,cancelable:false,pointerId:991,pointerType:"touch"})));await pause(60);
+  const foreign=await page.$eval("#viewport",v=>({owner:v.dataset.walkMoveStickOwner,foreign:v.dataset.walkMoveStickForeignCapture}));if(foreign.owner!=="773"||foreign.foreign!=="991")throw new Error(`foreign capture stole move ownership: ${JSON.stringify(foreign)}`);
+  await page.evaluate(({x,y})=>window.dispatchEvent(new PointerEvent("pointermove",{bubbles:true,cancelable:true,pointerId:773,pointerType:"touch",button:0,buttons:1,clientX:x,clientY:y})),movePoint);await pause(60);
+  const resumed=await page.$eval("#viewport",v=>({move:v.dataset.walkMove,owner:v.dataset.walkMoveStickOwner}));if(resumed.owner!=="773"||String(resumed.move||"").startsWith("0.000,0.000"))throw new Error(`owned move did not resume after foreign capture: ${JSON.stringify(resumed)}`);
+
+  const shotsBefore=Number(await page.$eval("#viewport",v=>v.dataset.walkEnhancedShots||0));
+  await page.$eval("#footLookZone",el=>{const r=el.getBoundingClientRect(),id=992,x=r.left+r.width*.68,y=r.top+r.height*.40;el.dispatchEvent(new PointerEvent("pointerdown",{bubbles:true,cancelable:true,pointerId:id,pointerType:"touch",button:0,buttons:1,clientX:x,clientY:y}));el.dispatchEvent(new PointerEvent("pointermove",{bubbles:true,cancelable:true,pointerId:id,pointerType:"touch",button:0,buttons:1,clientX:x-70,clientY:y+45}));el.dispatchEvent(new PointerEvent("pointerup",{bubbles:true,cancelable:true,pointerId:id,pointerType:"touch",button:0,buttons:0,clientX:x-70,clientY:y+45}));});
+  await page.waitForFunction(before=>Number(document.querySelector("#viewport")?.dataset.walkEnhancedShots||0)>before,{timeout:2500},shotsBefore);await pause(80);
+  const afterFire=await page.$eval("#viewport",v=>({move:v.dataset.walkMove,owner:v.dataset.walkMoveStickOwner,ownership:v.dataset.walkTouchOwnership,hud:v.dataset.mobileLandscapeHud,collision:v.dataset.walkCollisionResolution,shots:Number(v.dataset.walkEnhancedShots||0),dead:v.dataset.playerDead}));
+  if(afterFire.owner!=="773"||String(afterFire.move||"").startsWith("0.000,0.000")||afterFire.ownership!=="left-move+right-look+screen-fire-no-drag-v2"||afterFire.hud!=="compact-real-estate-v2"||afterFire.collision!=="substep+building-edge-tangent-v1"||afterFire.dead==="1")throw new Error(`screen drag interrupted FPS input: ${JSON.stringify(afterFire)}`);
+
+  await page.evaluate(()=>window.dispatchEvent(new Event("blur")));await page.waitForFunction(()=>{const v=document.querySelector("#viewport");return v?.dataset.walkMoveStickOwner==="none"&&String(v.dataset.walkMove||"").startsWith("0.000,0.000");},{timeout:2000});
+  console.log(`Focused FPS input smoke passed: full-range move, foreign capture isolation, resumed owner input, screen-drag fire without move theft, current compact HUD, and wall-tangent collision owner: ${JSON.stringify({initial,foreign,resumed,afterFire})}`);
+}finally{await browser.close();}

--- a/tests/walk_collision_resolution_test.mjs
+++ b/tests/walk_collision_resolution_test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import {resolveWalkCollisionMove} from "../sim/walk_collision_resolution.mjs";
+
+const wall=[{points:[[0,-4],[0,4],[1,4],[1,-4]]}];
+const freeLeft=(x,y)=>Number(x)<-.0001&&Math.abs(Number(y))<10;
+const stuckBase=from=>({x:Number(from.x)||0,y:Number(from.y)||0});
+
+const free=resolveWalkCollisionMove({x:-.4,y:0},{x:-.6,y:.3},{canOccupy:freeLeft,baseResolve:stuckBase,prisms:wall});
+assert(Math.abs(free.x+.6)<1e-9&&Math.abs(free.y-.3)<1e-9,"free movement must remain exact");
+
+const slide=resolveWalkCollisionMove({x:-.10,y:0},{x:.10,y:.22},{canOccupy:freeLeft,baseResolve:stuckBase,prisms:wall});
+assert(slide.x<0,"wall slide must stay outside the building");
+assert(slide.y>.12,"diagonal input must preserve tangential progress instead of sticking");
+assert.equal(slide.__walkCollisionSlide,true,"wall contact should report tangent slide");
+
+const perpendicular=resolveWalkCollisionMove({x:-.10,y:0},{x:.10,y:0},{canOccupy:freeLeft,baseResolve:stuckBase,prisms:wall});
+assert(Math.abs(perpendicular.y)<1e-9,"pressing straight into a wall must not invent sideways movement");
+assert(perpendicular.x<0,"perpendicular wall contact must not enter the building");
+
+let fallbackCalls=0;
+const vehicleFallback=resolveWalkCollisionMove({x:0,y:0},{x:.1,y:.1},{canOccupy:(x,y)=>!(x>.05&&y>.05),baseResolve:()=>{fallbackCalls++;return{x:.04,y:0};},prisms:[]});
+assert.equal(fallbackCalls,1,"non-building blockers should retain the base resolver");
+assert.deepEqual(vehicleFallback,{x:.04,y:0});
+
+console.log("WALK collision resolution passed: substeps preserve free motion, rotated/building wall contact slides tangentially, perpendicular contact does not auto-strafe, and non-building blockers fall back cleanly.");


### PR DESCRIPTION
Fixes the real WALK building-stick mechanism by adding substepped wall-tangent resolution on top of the existing occupancy model, without changing Box3D drone physics. Replaces the stale oversized FPS deploy smoke with a focused current input smoke, and gates the release on the existing 19-target drag-fire stress so the target shooting regression is verified directly. Adds a deterministic collision regression test.