### PR TITLE
Preserve WALK resolver for non-building blockers

### DIFF
--- a/sim/walk_collision_resolution.mjs
+++ b/sim/walk_collision_resolution.mjs
@@ -33,6 +33,7 @@ export function resolveWalkCollisionMove(fromValue,toValue,{canOccupy,baseResolv
   if(typeof canOccupy!=="function")return fallback();
   if(!safeOccupy(canOccupy,from.x,from.y))return fallback();
   if(safeOccupy(canOccupy,to.x,to.y))return to;
+  if(!nearbyBuildingEdges(to,prisms).length)return fallback();
   const dx=to.x-from.x,dy=to.y-from.y,distance=Math.hypot(dx,dy);if(distance<=EPS)return from;
   const steps=Math.max(1,Math.ceil(distance/MAX_SUBSTEP_M)),stepX=dx/steps,stepY=dy/steps;
   let current={...from},moved=false,slid=false;


### PR DESCRIPTION
Hotfix for PR #179 deploy gate. The wall-tangent resolver now activates only when the blocked destination is actually near building prism edges; vehicle/other blockers keep the pre-existing base resolver. No fire/target runtime change.